### PR TITLE
[73] - Mobile Modals update

### DIFF
--- a/frontend/src/components/page-about/shared/teamCard.js
+++ b/frontend/src/components/page-about/shared/teamCard.js
@@ -8,6 +8,7 @@ const modalStyles = {
     backgroundColor: null,
   },
   content: {
+    margin: "2rem",
     position: null,
     padding: null,
     border: null,

--- a/frontend/src/components/page-about/shared/teamCard.js
+++ b/frontend/src/components/page-about/shared/teamCard.js
@@ -8,7 +8,6 @@ const modalStyles = {
     backgroundColor: null,
   },
   content: {
-    margin: "2rem",
     position: null,
     padding: null,
     border: null,

--- a/frontend/src/css/global.css
+++ b/frontend/src/css/global.css
@@ -70,7 +70,7 @@ p {
 }
 
 .ReactModal__Content {
-  @apply sm:max-w-[19.625rem] lg:max-w-container mx-auto sm:my-8 border-none;
+  @apply sm:max-w-[19.625rem] lg:max-w-container m-8 sm:mx-auto sm:my-8 border-none;
 }
 
 .ReactModal__Body--open,


### PR DESCRIPTION
fixed the issue with mobile modals sticking just to the top. theres a small margin around the small mobile views now

mobile view of smaller height modal
<img width="486" alt="Screenshot 2023-12-17 at 4 34 10 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/96ce9840-5067-47e7-8499-7c8efa9d2db8">

mobile view of large height modal
<img width="493" alt="Screenshot 2023-12-17 at 4 34 44 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/d41a509d-213b-4a56-a7b3-935a70744594">

medium desktop view unaffected
<img width="620" alt="Screenshot 2023-12-17 at 4 37 01 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/b42cb772-1468-41b3-8861-109804f1c4cd">

largest views unaffected
<img width="1440" alt="Screenshot 2023-12-17 at 4 35 57 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/479c4030-f3e3-4b75-84de-1d25bb722ad9">
