### PR TITLE
[85] Top Bar Above Nav White Issue Fix

### DIFF
--- a/frontend/src/css/global.css
+++ b/frontend/src/css/global.css
@@ -4,6 +4,10 @@
 @tailwind components;
 @tailwind utilities;
 
+body {
+  @apply bg-Primary-700;
+}
+
 .triangle-left {
   @apply left-0;
 }


### PR DESCRIPTION
firefox
<img width="312" alt="Screenshot 2023-12-23 at 11 39 56 AM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/40f7965a-d7bb-4550-bc93-bd4ef85f5fd0">

safari
<img width="310" alt="Screenshot 2023-12-23 at 11 40 19 AM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/0f8a79c5-e185-4daf-a1c1-7682a8ab09ed">

chrome - has default dark gray pull to refresh for dark mode iphone, not sure how to change this one but to be honest i think it looks fine
![top-nav-chrome](https://github.com/hmcc-global/hmccaa-web/assets/88253868/fdd4c78b-7429-402e-b81b-e2dbd9ab37a6)
