### PR TITLE
[86] Instagram bar not full width + footer links fix + update map url

### DIFF
--- a/frontend/src/components/footer.js
+++ b/frontend/src/components/footer.js
@@ -19,11 +19,14 @@ const Footer = () => {
     { title: "Watch", route: "/watch" },
     { title: "Give", route: "/give" },
   ];
+  // TODO: what is interest form? 
+  // fix remainder of routes when their sections get added
+  // all link to next steps for now
   const connectList = [
     { title: "Interest Form", route: "/" },
-    { title: "Join a LIFE Group", route: "/" },
-    { title: "Become a Member", route: "/" },
-    { title: "Join a Ministry Team", route: "/" },
+    { title: "Join a LIFE Group", route: "/next-steps/lifegroups" },
+    { title: "Become a Member", route: "/next-steps" },
+    { title: "Join a Ministry Team", route: "/next-steps" },
   ];
   return (
     <footer>
@@ -72,7 +75,6 @@ const Footer = () => {
                   {connectList.map((item, index) => (
                     <a
                       key={`connectLink-${index}`}
-                      target="_blank"
                       rel="noreferrer"
                       href={item.route}
                       className="text-Shades-0 font-medium text-start text-sm leading-normal mb-0 no-underline hover:opacity-75"

--- a/frontend/src/components/instaBar.js
+++ b/frontend/src/components/instaBar.js
@@ -1,13 +1,14 @@
 import * as React from "react";
 import { InstaIcon } from "./svgs";
 
+// could make entire bar clickable to link to ig page?
 const Instagram = () => (
   <div className="bg-Shades-100 py-5 w-full">
     <div className="flex place-content-center gap-x-3">
       <div>
         <InstaIcon className="w-5 h-5 lg:w-10 lg:h-10" />
       </div>
-      <h3 className="text-Shades-0 font-medium text-sm lg:text-2xl font-inter leading-[normal]">
+      <h3 className="text-Shades-0 font-medium text-sm lg:text-2xl font-inter leading-relaxed">
         Follow us on Instagram @HMCC_AA
       </h3>
     </div>

--- a/frontend/src/components/page-connect/map-details.js
+++ b/frontend/src/components/page-connect/map-details.js
@@ -22,7 +22,7 @@ const MapDetails = () => {
             <SecondaryButtonLink
               hasArrow={true}
               className={"bg-Shades-0"}
-              to="https://maps.app.goo.gl/K7Z126sj78wQjuGY7"
+              to="https://www.google.com/maps/place/Harvest+Mission+Community+Church/@42.2816338,-83.7372209,17z/data=!4m5!3m4!1s0x883cae6a77eef201:0xaf4019d9fc7aec8e!8m2!3d42.2816359!4d-83.7371982?hl=en&shorturl=1"
             >
               MAPS & DIRECTIONS
             </SecondaryButtonLink>

--- a/frontend/src/pages/connect/index.js
+++ b/frontend/src/pages/connect/index.js
@@ -15,8 +15,8 @@ const ConnectPage = () => (
       <SundayCelebration />
       <MapDetails />
       <Questions />
-      <Instagram />
     </div>
+    <Instagram />
   </Layout>
 );
 


### PR DESCRIPTION
on the connect page. event page has an ig bar too but its already full width. tested on different screen sizes
<img width="1085" alt="Screenshot 2023-12-23 at 2 04 54 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/94d562a5-8aac-4d75-ae9f-18b61dd8bffa">

ways to connect, updated to point to next steps. although i dont know where the interest form is so its blank for now
<img width="1010" alt="Screenshot 2023-12-23 at 2 05 12 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/72bd5b7c-6e1d-4908-9759-45c4d54b00ca">

url pointed to maps.app which loaded a bit slower than the url in the footer link. changed it to be more consistent
<img width="806" alt="Screenshot 2023-12-23 at 2 06 09 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/fe2f8a03-f8b9-498a-95cc-3e6ea261d3b8">
