### PR TITLE
[71] Events page business logic

### DIFF
--- a/frontend/src/components/page-events/event-processing-util.js
+++ b/frontend/src/components/page-events/event-processing-util.js
@@ -1,0 +1,126 @@
+
+const STRAPI_RECURRING_TIME = "event-times.recurring-time";
+const STRAPI_SINGLE_TIME = "event-times.single-time";
+
+
+const addDays = (date, days) => {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+};
+
+const addWeeks = (date, weeks) => {
+  const result = new Date(date);
+  result.setDate(result.getDate() + weeks * 7);
+  return result;
+};
+
+const addMonths = (date, months) => {
+  const result = new Date(date);
+  result.setMonth(result.getMonth() + months);
+  return result;
+};
+
+const addYears = (date, years) => {
+  const result = new Date(date);
+  result.setFullYear(result.getFullYear() + years);
+  return result;
+};
+
+/*
+  * Returns whether the date is before today.
+  * We don't want events to disappear immediately after they start.
+  * We'll use this function to keep showing events until the end of the same day.
+ */
+const isTodayOrAfter = (date) => {
+  const copyOfDate = new Date(date);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  return copyOfDate > today;
+};
+
+const DATE_ITERATOR = {
+  "Day": addDays,
+  "Week": addWeeks,
+  "Month": addMonths,
+  "Year": addYears,
+};
+
+const generateRecurringEvent = (timeInfo, baseEvent, maxOccurrences) => {
+  maxOccurrences = maxOccurrences || 1;
+  const startDate = new Date(timeInfo.DateTime);
+  const events = [];
+  const duration = timeInfo.EndDateTime ? new Date(timeInfo.EndDateTime) - startDate : null;
+
+  for (let i = 0; i < maxOccurrences; i++) {
+    const eventDate = DATE_ITERATOR[timeInfo.RecurTimeFrame](startDate, i * timeInfo.RecurEveryXTimeFrames);
+
+    // Stop generating events after the end date
+    if (timeInfo.EndRecurDate && eventDate > new Date(timeInfo.EndRecurDate)) {
+      break;
+    }
+
+    if (isTodayOrAfter(eventDate) || !timeInfo.StopShowingWhenPast) {
+      events.push({
+        ...baseEvent,
+        date: eventDate,
+        endDate: duration ? new Date(eventDate.getTime() + duration) : null,
+      })
+    }
+
+  }
+  return events;
+};
+
+const processEvent = (event) => {
+  const eventInstances = [];
+
+  const fullDescription = event.DescriptionOverride || event.EventTemplate?.Description || "";
+  const [description] = fullDescription.split("\n");
+  const baseEvent = {
+    title: event.NameOverride || event.EventTemplate?.Name || "",
+    imgUrl: event.CoverImageOverride?.url || event.EventTemplate?.CoverImage.url || "",
+    imgAlt: event.CoverImageOverride?.imgAlt || event.EventTemplate?.CoverImage.imgAlt || "",
+    location: event.LocationOverride?.LocationName || event.EventTemplate?.Location.LocationName || "",
+    description,
+  };
+
+  for (const time of (event.Time || [])) {
+    if (time.strapi_component === STRAPI_RECURRING_TIME) {
+      const recurringInstances = generateRecurringEvent(
+        time, baseEvent, event.EventTemplate?.ShowXUpcomingEvents
+      );
+      eventInstances.push(...recurringInstances);
+    }
+    else if (time.strapi_component === STRAPI_SINGLE_TIME) {
+      if (isTodayOrAfter(time.DateTime) || !time.StopShowingWhenPast) {
+        const eventInstance = {
+          ...baseEvent,
+          date: new Date(time.DateTime),
+          endDate: time.EndDateTime ? new Date(time.EndDateTime) : null,
+        };
+        eventInstances.push(eventInstance);
+      }
+    }
+  }
+
+  // Sort events
+  eventInstances.sort((a, b) => a.date - b.date);
+
+  // Truncate events to first X
+  return eventInstances.slice(0, event.EventTemplate?.ShowXUpcomingEvents || 1);
+};
+
+export const processEvents = (events) => {
+  const displayEvents = [];
+  events.forEach((event) => {
+    const eventInstances = processEvent(event);
+    displayEvents.push(...eventInstances);
+  });
+
+  // Sort events
+  displayEvents.sort((a, b) => a.date - b.date);
+
+  return displayEvents;
+};

--- a/frontend/src/pages/events/index.js
+++ b/frontend/src/pages/events/index.js
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useStaticQuery, graphql } from "gatsby";
 
 import Layout from "../../components/layout";
 import Seo from "../../components/seo";
@@ -8,60 +9,57 @@ import { StaticImage } from "gatsby-plugin-image";
 import EventCard from "../../components/page-events/eventCard";
 import PrayerGatheringEvents from "../../components/page-events/prayerGatheringEvents";
 import Banner from "../../components/shared/banner";
+import {processEvents} from "../../components/page-events/event-processing-util";
 
 const EventsPage = () => {
-  // multiple events hardcoded to test layout with multiple events
-  const events = [
-    {
-      id: 1,
-      title: "Prayer Gathering",
-      date: "Th, May 25, 2023",
-      imgUrl: "../../images/prayer-gathering.png",
-      imgAlt: "example",
-      location: "T-Center",
-      description: "Event at HMCC where you go to pray and worship God",
-    },
-    {
-      id: 2,
-      title: "Another Event",
-      date: "Th, May 25, 2023",
-      imgUrl: "../../images/prayer-gathering.png",
-      imgAlt: "example",
-      location: "T-Center",
-      description:
-        "Event at HMCC where you go to engage in this event at HMCC. This description is a bit longer.",
-    },
-    {
-      id: 3,
-      title: "One more Event",
-      date: "Th, May 25, 2023",
-      imgUrl: "../../images/prayer-gathering.png",
-      imgAlt: "example",
-      location: "T-Center",
-      description:
-        "Event at HMCC where you go to engage in this event at HMCC. This description is a bit longer.",
-    },
-    {
-      id: 4,
-      title: "One more Event",
-      date: "Th, May 25, 2023",
-      imgUrl: "../../images/prayer-gathering.png",
-      imgAlt: "example",
-      location: "T-Center",
-      description:
-        "Event at HMCC where you go to engage in this event at HMCC. This description is a bit longer. Now this description is really long and spans many lines.",
-    },
-    {
-      id: 5,
-      title: "Last Event",
-      date: "Th, May 25, 2023",
-      imgUrl: "../../images/prayer-gathering.png",
-      imgAlt: "example",
-      location: "T-Center",
-      description:
-        "Event at HMCC where you go to engage in this event at HMCC.",
-    },
-  ]; // TODO: fetch actual events from backend
+  const data = useStaticQuery(graphql`
+    query EventQuery {
+      allStrapiEvent {
+        nodes {
+          DescriptionOverride
+          EventTemplate {
+            CoverImage {
+              url
+            }
+            Description
+            Location {
+              LocationName
+            }
+            Name
+            ShowXUpcomingEvents
+          }
+          LocationOverride {
+            LocationName
+          }
+          NameOverride
+          Time {
+            ... on STRAPI__COMPONENT_EVENT_TIMES_RECURRING_TIME {
+              id
+              DateTime
+              EndDateTime
+              EndRecurDate
+              RecurEveryXTimeFrames
+              RecurTimeFrame
+              StopShowingWhenPast
+              strapi_component
+            }
+            ... on STRAPI__COMPONENT_EVENT_TIMES_SINGLE_TIME {
+              id
+              StopShowingWhenPast
+              EndDateTime
+              DateTime
+              strapi_component
+            }
+          }
+          CoverImageOverride {
+            url
+          }
+        }
+      }
+    }
+  `);
+
+  const events = processEvents(data.allStrapiEvent.nodes);
 
   return (
     <Layout>
@@ -72,7 +70,7 @@ const EventsPage = () => {
           <EventCard
             key={event.id}
             title={event.title}
-            date={event.date}
+            date={event.date.toString()}
             // TODO: use GatsbyImage since static cannot handle dynamic src
             img={
               <StaticImage


### PR DESCRIPTION
Fetch events from CMS, and add filtering according to rules.

Test cases verified:
* Empty event with no event template doesn't break the site
* Empty event with a single time
* Event completely using template
* Event with overrides
* Recurring event every day
* Recurring event every 4 days
* Recurring event every 2 weeks
* Recurring event every 2 months
* Recurring event every year
* End Recur date
* Recurring and single event together with showing X future events
* StopShowingWhenPast for single event
* ShowXUpcomingEvents defaults to 1 if no event template
* Events today keep showing until the end of the day