### PR TITLE
[90] link refactor - terrianx/link refactor

### DIFF
--- a/frontend/src/components/Button.js
+++ b/frontend/src/components/Button.js
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Link as GatsbyLink } from "gatsby";
+import Link from "./Link";
 import { ButtonArrow } from "./svgs";
 import {
   button,
@@ -8,14 +8,15 @@ import {
   primaryButton,
 } from "../css/button.module.css";
 
+// ...props captures 'to' or the 'href' parameter
 export const ButtonLink = ({
-  to = "#",
   hasArrow = false,
   className = "",
   children,
   customClassName,
+  ...props
 }) => (
-  <GatsbyLink className={`${button} ${className} ${customClassName?.button}`} to={to}>
+  <Link className={`${button} ${className} ${customClassName?.button}`} {...props}>
     <span
       className={`${(hasArrow && textContainer) || ""} ${
         customClassName?.textContainer || ""
@@ -24,7 +25,7 @@ export const ButtonLink = ({
       {children}
     </span>{" "}
     {hasArrow && <ButtonArrow />}
-  </GatsbyLink>
+  </Link>
 );
 
 export const Button = ({

--- a/frontend/src/components/Button.js
+++ b/frontend/src/components/Button.js
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Link } from "gatsby";
+import { Link as GatsbyLink } from "gatsby";
 import { ButtonArrow } from "./svgs";
 import {
   button,
@@ -15,7 +15,7 @@ export const ButtonLink = ({
   children,
   customClassName,
 }) => (
-  <Link className={`${button} ${className} ${customClassName?.button}`} to={to}>
+  <GatsbyLink className={`${button} ${className} ${customClassName?.button}`} to={to}>
     <span
       className={`${(hasArrow && textContainer) || ""} ${
         customClassName?.textContainer || ""
@@ -24,7 +24,7 @@ export const ButtonLink = ({
       {children}
     </span>{" "}
     {hasArrow && <ButtonArrow />}
-  </Link>
+  </GatsbyLink>
 );
 
 export const Button = ({

--- a/frontend/src/components/Link.js
+++ b/frontend/src/components/Link.js
@@ -1,29 +1,27 @@
 import * as React from "react";
 import { Link as GatsbyLink} from "gatsby";
 
-const Link = ({ href, to, children }) => {
+const Link = ({ href, to, children, ...rest }) => {
   // external link
   if (href) {
     return (
-      <a 
-        href={href}
-        target="_blank"
-        rel="noreferrer"
-      >
+      <a href={href} target="_blank" rel="noreferrer" {...rest}>
         {children}
       </a>
     );
   // internal link
   } else if (to) {
     return (
-      <GatsbyLink to={to}>
+      <GatsbyLink to={to} {...rest}>
         {children}
       </GatsbyLink>
     );
   }
 
   return (
-    <div>{children}</div>
+    <div {...rest}>
+      {children}
+    </div>
   );
 };
 

--- a/frontend/src/components/Link.js
+++ b/frontend/src/components/Link.js
@@ -16,8 +16,6 @@ const Link = ({ href, to, children, ...props }) => {
   // note: to may not be defined, make link redirect to home
   if (!to) {
     to = "#";
-    // debug
-    alert('to not specified');
   }
 
   // fall back on internal link

--- a/frontend/src/components/Link.js
+++ b/frontend/src/components/Link.js
@@ -3,27 +3,26 @@ import { Link as GatsbyLink} from "gatsby";
 
 // specifying to as a prop will render gatsby's link component
 // if an href is specified native anchor is used for external links
-const Link = ({ href, to, children, ...rest }) => {
+const Link = ({ href, to, children, ...props }) => {
   // external link
   if (href) {
     return (
-      <a href={href} target="_blank" rel="noreferrer" {...rest}>
+      <a href={href} target="_blank" rel="noreferrer" {...props}>
         {children}
       </a>
     );
-  // internal link
-  } else if (to) {
-    return (
-      <GatsbyLink to={to} {...rest}>
-        {children}
-      </GatsbyLink>
-    );
   }
 
+  // note: to may not be defined, make link redirect to home
+  if (!to) {
+    to = "#";
+  }
+
+  // fall back on internal link
   return (
-    <div {...rest}>
+    <GatsbyLink to={to} {...props}>
       {children}
-    </div>
+    </GatsbyLink>
   );
 };
 

--- a/frontend/src/components/Link.js
+++ b/frontend/src/components/Link.js
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { Link as GatsbyLink} from "gatsby";
 
+// specifying to as a prop will render gatsby's link component
+// if an href is specified native anchor is used for external links
 const Link = ({ href, to, children, ...rest }) => {
   // external link
   if (href) {

--- a/frontend/src/components/Link.js
+++ b/frontend/src/components/Link.js
@@ -1,0 +1,10 @@
+import * as React from "react";
+import { Link as GatsbyLink} from "gatsby";
+
+const Link = ({
+
+}) => (
+  <></>
+);
+
+export default Link;

--- a/frontend/src/components/Link.js
+++ b/frontend/src/components/Link.js
@@ -16,6 +16,8 @@ const Link = ({ href, to, children, ...props }) => {
   // note: to may not be defined, make link redirect to home
   if (!to) {
     to = "#";
+    // debug
+    alert('to not specified');
   }
 
   // fall back on internal link

--- a/frontend/src/components/Link.js
+++ b/frontend/src/components/Link.js
@@ -15,7 +15,7 @@ const Link = ({ href, to, children, ...props }) => {
 
   // note: to may not be defined, make link redirect to home
   if (!to) {
-    to = "#";
+    to = "/";
   }
 
   // fall back on internal link

--- a/frontend/src/components/Link.js
+++ b/frontend/src/components/Link.js
@@ -1,10 +1,30 @@
 import * as React from "react";
 import { Link as GatsbyLink} from "gatsby";
 
-const Link = ({
+const Link = ({ href, to, children }) => {
+  // external link
+  if (href) {
+    return (
+      <a 
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+      >
+        {children}
+      </a>
+    );
+  // internal link
+  } else if (to) {
+    return (
+      <GatsbyLink to={to}>
+        {children}
+      </GatsbyLink>
+    );
+  }
 
-}) => (
-  <></>
-);
+  return (
+    <div>{children}</div>
+  );
+};
 
 export default Link;

--- a/frontend/src/components/footer.js
+++ b/frontend/src/components/footer.js
@@ -8,6 +8,7 @@ import facebookLogo from "../images/icons/facebook.svg";
 import instagramLogo from "../images/icons/instagram.svg";
 import twitterLogo from "../images/icons/twitter.svg";
 import { CopyrightLogo } from "./svgs";
+import Link from "./Link";
 
 const Footer = () => {
   const browseList = [
@@ -57,13 +58,13 @@ const Footer = () => {
                     Browse
                   </h2>
                   {browseList.map((item, index) => (
-                    <a
+                    <Link
                       key={`browseLink-${index}`}
-                      href={item.route}
+                      to={item.route}
                       className="text-Shades-0 font-medium text-start text-sm leading-normal mb-4 md:mb-0 no-underline hover:opacity-75"
                     >
                       {item.title}
-                    </a>
+                    </Link>
                   ))}
                 </div>
               </div>
@@ -73,14 +74,13 @@ const Footer = () => {
                     Ways to Connect
                   </h2>
                   {connectList.map((item, index) => (
-                    <a
+                    <Link
                       key={`connectLink-${index}`}
-                      rel="noreferrer"
-                      href={item.route}
+                      to={item.route}
                       className="text-Shades-0 font-medium text-start text-sm leading-normal mb-4 md:mb-0 no-underline hover:opacity-75"
                     >
                       {item.title}
-                    </a>
+                    </Link>
                   ))}
                 </div>
               </div>
@@ -102,14 +102,12 @@ const Footer = () => {
                   className="w-[24px] h-[24px] mb-0"
                   src={mapPinLogo}
                 />
-                <a
-                  target="_blank"
-                  rel="noreferrer"
+                <Link
                   href="https://www.google.com/maps/place/Harvest+Mission+Community+Church/@42.2816338,-83.7372209,17z/data=!4m5!3m4!1s0x883cae6a77eef201:0xaf4019d9fc7aec8e!8m2!3d42.2816359!4d-83.7371982?hl=en&shorturl=1"
                   className="text-Shades-0 font-medium text-center text-sm leading-normal mb-0 ml-[12px] no-underline hover:opacity-75"
                 >
                   1001 E Huron St, Ann Arbor, MI 48104
-                </a>
+                </Link>
               </div>
               <div className="flex flex-row justify-center items-center mt-[15px]">
                 <img
@@ -117,12 +115,12 @@ const Footer = () => {
                   className="w-[24px] h-[24px] mb-0"
                   src={mailLogo}
                 />
-                <a
+                <Link
                   href="mailto:annarbor@hmcc.net"
                   className="text-Shades-0 font-medium text-center text-sm leading-normal mb-0 ml-[12px] no-underline hover:opacity-75"
                 >
                   annarbor@hmcc.net
-                </a>
+                </Link>
               </div>
               <div className="flex flex-row justify-center items-center mt-[15px]">
                 <img
@@ -135,10 +133,8 @@ const Footer = () => {
                 </h2>
               </div>
               <div className="flex flex-row justify-center items-center mt-[20px] gap-[20px]">
-                <a
+                <Link
                   href="https://www.facebook.com/hmcc.aa/"
-                  target="_blank"
-                  rel="noreferrer"
                   className="hover:opacity-75"
                 >
                   <img
@@ -146,11 +142,9 @@ const Footer = () => {
                     className="w-[32px] h-[32px] mb-0"
                     src={facebookLogo}
                   />
-                </a>
-                <a
+                </Link>
+                <Link
                   href="https://www.instagram.com/hmcc_aa/"
-                  target="_blank"
-                  rel="noreferrer"
                   className="hover:opacity-75"
                 >
                   <img
@@ -158,11 +152,9 @@ const Footer = () => {
                     className="w-[32px] h-[32px] mb-0"
                     src={instagramLogo}
                   />
-                </a>
-                <a
+                </Link>
+                <Link
                   href="https://twitter.com/HMCC_AA"
-                  target="_blank"
-                  rel="noreferrer"
                   className="hover:opacity-75"
                 >
                   <img
@@ -170,7 +162,7 @@ const Footer = () => {
                     className="w-[32px] h-[32px] mb-0"
                     src={twitterLogo}
                   />
-                </a>
+                </Link>
               </div>
             </div>
           </div>
@@ -181,12 +173,12 @@ const Footer = () => {
               <h2 className="text-Shades-0 text-sm md:text-lg font-normal mb-0 ml-1 tracking-medium-wide md:tracking-normal">
                 2023
               </h2>
-              <a
+              <Link
                 href="https://annarbor.hmcc.net"
                 className="text-Shades-0 text-sm md:text-lg leading-tighter font-medium md:font-semibold mb-0 ml-1 md:ml-3 no-underline hover:opacity-75 tracking-medium-wide"
               >
                 HARVEST MISSION COMMUNITY CHURCH
-              </a>
+              </Link>
             </div>
           </div>
         </div>

--- a/frontend/src/components/footer.js
+++ b/frontend/src/components/footer.js
@@ -174,7 +174,7 @@ const Footer = () => {
                 2023
               </h2>
               <Link
-                href="https://annarbor.hmcc.net"
+                to="/"
                 className="text-Shades-0 text-sm md:text-lg leading-tighter font-medium md:font-semibold mb-0 ml-1 md:ml-3 no-underline hover:opacity-75 tracking-medium-wide"
               >
                 HARVEST MISSION COMMUNITY CHURCH

--- a/frontend/src/components/header.js
+++ b/frontend/src/components/header.js
@@ -131,13 +131,21 @@ const Header = () => {
             </div>
             <div className="hidden peer-hover:flex hover:flex w-[150px] flex-col absolute bg-[#1A56D6]">
               {locationsList.map((item, index) => (
-                <Link
-                  key={`browseLink-${index}`}
-                  href={item.route}
-                  className={`${textStyle} hover:bg-[#0C2966] py-2 px-4 border-b-[0.1px] border-gray-100 tracking-[0.96px]`}
-                >
-                  {item.title}
-                </Link>
+                index == 0 
+                  ? <Link
+                    key={`browseLink-${index}`}
+                    to={"/"}
+                    className={`${textStyle} hover:bg-[#0C2966] py-2 px-4 border-b-[0.1px] border-gray-100 tracking-[0.96px]`}
+                  >
+                    {item.title}
+                  </Link>
+                  : <Link
+                    key={`browseLink-${index}`}
+                    href={item.route}
+                    className={`${textStyle} hover:bg-[#0C2966] py-2 px-4 border-b-[0.1px] border-gray-100 tracking-[0.96px]`}
+                  >
+                    {item.title}
+                  </Link>
               ))}
               <Link
                 href="https://tangerang.hmcc.net/"

--- a/frontend/src/components/header.js
+++ b/frontend/src/components/header.js
@@ -3,7 +3,7 @@ import hmccLogo from "../images/hmcc-ripple-white.svg";
 import mapPinLogo from "../images/icons/map-pin.svg";
 import dropDown from "../images/icons/dropdown.svg";
 import x from "../images/icons/X.svg";
-import { Link } from "gatsby";
+import Link from "./Link";
 
 const Header = () => {
   const browseList = [
@@ -68,7 +68,7 @@ const Header = () => {
         </div>
 
         <div className="hidden lg:flex items-center gap-4 md:gap-6 lg:gap-8">
-          <Link href="/">
+          <Link to="/">
             <img alt="hmcc logo" className={logoStyle} src={hmccLogo} />
           </Link>
           <Link to="/" className={`${textStyle} w-[183px] font-semibold`}>
@@ -133,16 +133,14 @@ const Header = () => {
               {locationsList.map((item, index) => (
                 <Link
                   key={`browseLink-${index}`}
-                  to={item.route}
-                  target="_blank"
+                  href={item.route}
                   className={`${textStyle} hover:bg-[#0C2966] py-2 px-4 border-b-[0.1px] border-gray-100 tracking-[0.96px]`}
                 >
                   {item.title}
                 </Link>
               ))}
               <Link
-                to="https://tangerang.hmcc.net/"
-                target="_blank"
+                href="https://tangerang.hmcc.net/"
                 className={`${textStyle} hover:bg-[#0C2966] py-2 px-4 tracking-[0.96px]`}
               >
                 Tangerang

--- a/frontend/src/components/page-about/index/feedback.js
+++ b/frontend/src/components/page-about/index/feedback.js
@@ -24,7 +24,7 @@ const Feedback = () => {
         </div>
         <div>
           <div className="flex">
-            <SecondaryButtonLink to={"/about/feedback"} hasArrow={true}>
+            <SecondaryButtonLink href="#" hasArrow={true}>
               Feedback Form
             </SecondaryButtonLink>
           </div>

--- a/frontend/src/components/page-about/shared/teamCard.js
+++ b/frontend/src/components/page-about/shared/teamCard.js
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from "react";
 import Modal from "react-modal";
 import { MailIcon, CloseIcon } from "../../svgs";
+import Link from "../../Link";
 
 Modal.setAppElement("#___gatsby");
 const modalStyles = {
@@ -76,12 +77,12 @@ const TeamCard = ({ info, customClassName, showModal = false }) => {
                   <MailIcon className="w-5 h-5" />
                 </span>
               )}
-              <a
+              <Link
                 href={`mailto:${info.email}`}
                 className="no-underline text-Shades-100 break-all"
               >
                 {info.email}
-              </a>
+              </Link>
             </div>
           )}
         </div>
@@ -124,12 +125,12 @@ const TeamCard = ({ info, customClassName, showModal = false }) => {
                           <MailIcon className="w-8 h-8" />
                         </span>
                       )}
-                      <a
+                      <Link
                         href={`mailto:${member?.email}`}
                         className="no-underline text-Shades-100 break-all font-normal"
                       >
                         {member?.email}
-                      </a>
+                      </Link>
                     </div>
                   )}
                 </div>

--- a/frontend/src/components/page-connect/map-details.js
+++ b/frontend/src/components/page-connect/map-details.js
@@ -22,7 +22,7 @@ const MapDetails = () => {
             <SecondaryButtonLink
               hasArrow={true}
               className={"bg-Shades-0"}
-              to="https://www.google.com/maps/place/Harvest+Mission+Community+Church/@42.2816338,-83.7372209,17z/data=!4m5!3m4!1s0x883cae6a77eef201:0xaf4019d9fc7aec8e!8m2!3d42.2816359!4d-83.7371982?hl=en&shorturl=1"
+              href="https://www.google.com/maps/place/Harvest+Mission+Community+Church/@42.2816338,-83.7372209,17z/data=!4m5!3m4!1s0x883cae6a77eef201:0xaf4019d9fc7aec8e!8m2!3d42.2816359!4d-83.7371982?hl=en&shorturl=1"
             >
               MAPS & DIRECTIONS
             </SecondaryButtonLink>

--- a/frontend/src/components/page-give/how-to-give.js
+++ b/frontend/src/components/page-give/how-to-give.js
@@ -26,7 +26,7 @@ const HowToGiveSection = () => (
           deductions).
         </p>
         <PrimaryButtonLink
-          to="https://hmcc-aa.churchcenter.com/giving"
+          href="https://hmcc-aa.churchcenter.com/giving"
           hasArrow={true}
         >
           Give Now
@@ -66,7 +66,7 @@ const HowToGiveSection = () => (
         States. Year-end giving reports will be issued every January.
       </p>
     </div>
-    <SecondaryButtonLink to="https://hmcc-aa.churchcenter.com/giving/profile">
+    <SecondaryButtonLink href="https://hmcc-aa.churchcenter.com/giving/profile">
       View Donor Profile
     </SecondaryButtonLink>
   </div>

--- a/frontend/src/components/page-lifeGroups/fiveEs.js
+++ b/frontend/src/components/page-lifeGroups/fiveEs.js
@@ -73,8 +73,11 @@ const FiveEs = () => (
       ))}
     </div>
     <div className="flex justify-center font-bold pb-5 lg:pb-12">
-      <PrimaryButtonLink hasArrow={true}>
-        check out a life group
+      <PrimaryButtonLink
+        href="https://docs.google.com/forms/d/e/1FAIpQLSeSKeuDEtmv9mQAmm603df8IW82Uq6g_kiIKp-QnsUdBNcZbQ/viewform"
+        hasArrow={true}
+      >
+        CHECK OUT A LIFE GROUP
       </PrimaryButtonLink>
     </div>
     <div className="text-center lg:pb-[378px] max-w-[51.25rem] mx-auto font-medium lg:pt-0 lg:px-0 pt-7 pb-8 pr-2">

--- a/frontend/src/components/page-lifeGroups/topLGSummary.js
+++ b/frontend/src/components/page-lifeGroups/topLGSummary.js
@@ -47,7 +47,7 @@ const TopLGSummary = () => (
         </HighlightedParagraph>
         <div className="flex justify-center lg:justify-start">
           <SecondaryButtonLink
-            to="https://docs.google.com/forms/d/e/1FAIpQLSeSKeuDEtmv9mQAmm603df8IW82Uq6g_kiIKp-QnsUdBNcZbQ/viewform"
+            href="https://docs.google.com/forms/d/e/1FAIpQLSeSKeuDEtmv9mQAmm603df8IW82Uq6g_kiIKp-QnsUdBNcZbQ/viewform"
             hasArrow={true}
           >
             CHECK OUT A LIFE GROUP

--- a/frontend/src/components/page-new/lifeStages.js
+++ b/frontend/src/components/page-new/lifeStages.js
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { StaticImage } from "gatsby-plugin-image";
 import { bgLeft, bgRight } from "../../css/lifeStagesNew.module.css";
+import Link from "../Link";
 
 const lifeStages = [
   {
@@ -112,9 +113,9 @@ const LifeStages = () => {
       </div>
       <div className="text-Accent-500 text-center text-lg font-bold">
         Please email{" "}
-        <a href="mailto:abc@hmccaa.com" className="text-Accent-500">
+        <Link href="mailto:abc@hmccaa.com" className="text-Accent-500">
           abc@hmccaa.com
-        </a>{" "}
+        </Link>{" "}
         to get connected!
       </div>
     </div>

--- a/frontend/src/components/page-next-steps/ministryTeams.js
+++ b/frontend/src/components/page-next-steps/ministryTeams.js
@@ -17,6 +17,7 @@ import {
   WorshipLogo,
 } from "../svgs";
 import { StaticImage } from "gatsby-plugin-image";
+import Link from "../Link";
 
 const teams = [
   {
@@ -123,7 +124,7 @@ const MinistryTeams = () => (
           })}
         </div>
         <div className={highlightText}>
-          Please email <a href="mailto:abc@hmccaa.com">abc@hmccaa.com</a> to get
+          Please email <Link href="mailto:abc@hmccaa.com">abc@hmccaa.com</Link> to get
           connected!
         </div>
       </div>

--- a/frontend/src/components/page-watch/liveStream.js
+++ b/frontend/src/components/page-watch/liveStream.js
@@ -24,7 +24,7 @@ const LiveStream = () => {
           <div className="flex justify-center lg:justify-start">
             <PrimaryButtonLink
               hasArrow={true}
-              to="https://www.youtube.com/@hmcc_aa/streams"
+              href="https://www.youtube.com/@hmcc_aa/streams"
             >
               Watch Now
             </PrimaryButtonLink>

--- a/frontend/src/components/page-watch/rightNowMedia.js
+++ b/frontend/src/components/page-watch/rightNowMedia.js
@@ -40,7 +40,11 @@ const RightNowMedia = () => (
           </p>
         </div>
         <div className="flex justify-center lg:justify-start">
-          <SecondaryButtonLink hasArrow={true} className="bg-Shades-0">
+          <SecondaryButtonLink
+            href="#"
+            hasArrow={true}
+            className="bg-Shades-0"
+          >
             Sign Up For A Free Account
           </SecondaryButtonLink>
         </div>

--- a/frontend/src/pages/404.js
+++ b/frontend/src/pages/404.js
@@ -1,6 +1,5 @@
 import * as React from "react";
-import { Link } from "gatsby";
-
+import Link from "../components/Link";
 import Layout from "../components/layout";
 import Seo from "../components/seo";
 import { container } from "../css/404.module.css";
@@ -38,7 +37,7 @@ const NotFoundPage = () => (
           </div>
           <div className="pb-3">
             <Link
-              to="https://docs.google.com/forms/d/e/1FAIpQLSeSKeuDEtmv9mQAmm603df8IW82Uq6g_kiIKp-QnsUdBNcZbQ/viewform"
+              href="https://docs.google.com/forms/d/e/1FAIpQLSeSKeuDEtmv9mQAmm603df8IW82Uq6g_kiIKp-QnsUdBNcZbQ/viewform"
               className="text-Primary-300 font-extrabold text-start leading-normal underline decoration-0 hover:opacity-75 uppercase tracking-widest text-base"
             >
               Life Group Sign Up

--- a/frontend/src/pages/connect/life-stages.js
+++ b/frontend/src/pages/connect/life-stages.js
@@ -9,6 +9,7 @@ import {
   PrimaryButtonLink,
 } from "../../components/Button";
 import { lifeStage } from "../../css/lifeStages.module.css";
+import Link from "../../components/Link";
 
 const imageClassName =
   "bg-Shades-100 border-solid border-4  w-[260px] lg:w-[297px] relative z-10";
@@ -41,9 +42,9 @@ const lifeStages = [
         </p>
         <p>
           For more information or questions, please contact{" "}
-          <a href="mailto:covenant@annarbot.hmcc.net">
+          <Link href="mailto:covenant@annarbot.hmcc.net">
             covenant@annarbor.hmcc.net
-          </a>
+          </Link>
         </p>
       </div>
     ),
@@ -75,7 +76,7 @@ const lifeStages = [
         </p>
         <p>
           If you would like to learn more about our community, email{" "}
-          <a href="mailto:focus@annarbor.hmcc.net">focus@annarbor.hmcc.net</a>
+          <Link href="mailto:focus@annarbor.hmcc.net">focus@annarbor.hmcc.net</Link>
         </p>
       </div>
     ),
@@ -103,7 +104,7 @@ const lifeStages = [
         </p>
         <p>
           For more information contact{" "}
-          <a href="mailto:impact@annarbor.hmcc.net">impact@annarbor.hmcc.net</a>
+          <Link href="mailto:impact@annarbor.hmcc.net">impact@annarbor.hmcc.net</Link>
         </p>
       </div>
     ),
@@ -134,9 +135,9 @@ const lifeStages = [
           </p>
           <p>
             Want to know more about our Undergraduate ministry? Contact{" "}
-            <a href="mailto:access@annarbor.hmcc.net">
+            <Link href="mailto:access@annarbor.hmcc.net">
               access@annarbor.hmcc.net
-            </a>
+            </Link>
           </p>
           <p className="italic">
             Access, an MSA registered student organization, is the student branch
@@ -187,9 +188,9 @@ const lifeStages = [
         </p>
         <p>
           For more information about Global Access, contact{" "}
-          <a href="mailto:globalaccess@annarbor.hmcc.net">
+          <Link href="mailto:globalaccess@annarbor.hmcc.net">
             globalaccess@annarbor.hmcc.net.
-          </a>
+          </Link>
         </p>
       </div>
     ),
@@ -222,7 +223,7 @@ const lifeStages = [
         </p>
         <p>
           For more information about our youth ministry, contact{" "}
-          <a href="mailto:youth@annarbor.hmcc.net">youth@annarbor.hmcc.net</a>
+          <Link href="mailto:youth@annarbor.hmcc.net">youth@annarbor.hmcc.net</Link>
         </p>
       </div>
     ),
@@ -259,9 +260,9 @@ const lifeStages = [
         </p>
         <p>
           For more information about Building Blocks, contact{" "}
-          <a href="mailto:buildingblocks@annarbor.hmcc.net">
+          <Link href="mailto:buildingblocks@annarbor.hmcc.net">
             buildingblocks@annarbor.hmcc.net
-          </a>
+          </Link>
         </p>
       </div>
     ),
@@ -338,7 +339,7 @@ const LifeStagesPage = ({ pageContext }) => {
               another more consistently, we meet in LIFE Groups.
             </p>
             <div className="flex flex-col justify-center">
-              <PrimaryButtonLink to={""} hasArrow={true}>
+              <PrimaryButtonLink to={"../next-steps/lifegroups"} hasArrow={true}>
                 Check Out A Life Group
               </PrimaryButtonLink>
             </div>

--- a/frontend/src/pages/page-2.js
+++ b/frontend/src/pages/page-2.js
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Link } from "gatsby";
+import Link from "../components/Link";
 
 import Layout from "../components/layout";
 import Seo from "../components/seo";


### PR DESCRIPTION
**updated all links including gatsby links, anchors, buttonlinks (primary and secondary)**

links now all look like 

`<Link href="some external site" prop1=x prop2=y>Click here</Link>` 
or
`<Link to="some internal page" prop1=x prop2=y>Click here</Link>` 

href **must** be defined for an external link
to **must** be defined for internal page, otherwise it redirects to home page
any props can be passed down all the way to the original `<a>` or `<GatsbyLink>` element defined in components/Link.js
children can also be rendered in `Link`

i tested every link after making this change. every link that is currently working still works. #127 and #131 are some currently broken links.