### PR TITLE
Fix #128

### DIFF
--- a/frontend/src/components/instaBar.js
+++ b/frontend/src/components/instaBar.js
@@ -1,17 +1,19 @@
 import * as React from "react";
 import { InstaIcon } from "./svgs";
+import Link from "./Link";
 
-// could make entire bar clickable to link to ig page?
 const Instagram = () => (
   <div className="bg-Shades-100 py-5 w-full">
-    <div className="flex place-content-center gap-x-3">
+    <Link 
+      href="https://www.instagram.com/hmcc_aa/"
+      className="flex place-content-center gap-x-3 no-underline">
       <div>
         <InstaIcon className="w-5 h-5 lg:w-10 lg:h-10" />
       </div>
       <h3 className="text-Shades-0 font-medium text-sm lg:text-2xl font-inter leading-relaxed">
         Follow us on Instagram @HMCC_AA
       </h3>
-    </div>
+    </Link>
   </div>
 );
 


### PR DESCRIPTION
Clicking anywhere on black bar now links to external Instagram account

This version has some issues with events page graphql queries. But it is still up to date with main branch.

Error: 
GraphQLError: Unknown type "STRAPI__COMPONENT_EVENT_TIMES_SINGLE_TIME".