### PR TITLE
Fix #93 text wrapping on navigation bar

### DIFF
--- a/frontend/src/components/header.js
+++ b/frontend/src/components/header.js
@@ -182,7 +182,7 @@ const Header = () => {
           <div className={borderStyle}>
             <Link
               to="/new"
-              className={`${"min-w-max"} ${textStyle} ${
+              className={`min-w-max ${textStyle} ${
                 "/new/" === path ? "font-extrabold" : ""
               } font-bold hover:font-extrabold tracking-[0.96px]`}
             >

--- a/frontend/src/components/header.js
+++ b/frontend/src/components/header.js
@@ -63,7 +63,7 @@ const Header = () => {
             to="/"
             className={`${textStyle} text-center min-w-max font-semibold`}
           >
-            HARVEST MISSION <br/> COMMUNITY CHURCH
+            HARVEST MISSION <br /> COMMUNITY CHURCH
           </Link>
           <button onClick={toggleModal}>
             <img alt="drop down" className={dropDownStyle} src={dropDown} />
@@ -75,7 +75,7 @@ const Header = () => {
             <img alt="hmcc logo" className={logoStyle} src={hmccLogo} />
           </Link>
           <Link to="/" className={`${textStyle} min-w-max font-semibold`}>
-            HARVEST MISSION <br/> COMMUNITY CHURCH
+            HARVEST MISSION <br /> COMMUNITY CHURCH
           </Link>
         </div>
 

--- a/frontend/src/components/header.js
+++ b/frontend/src/components/header.js
@@ -28,7 +28,7 @@ const Header = () => {
     (typeof window !== "undefined" && window.location.pathname) || "";
   const containerStyle =
     "flex flex-row h-[60px]lg:h-[100px] relative flext-start bg-Primary-700 items-center justify-center pl-[18px] xl:pl-[80.286px] lg:pt-[40px] lg:pb-[17px] pr-[16px] 2xl:pr-[65px] [@media(min-width:1440px)]:gap-[140px] [@media(min-width:1600px)]:gap-[220px] position-fixed";
-  const logoStyle = "w-[80px] h-[32px] mb-0";
+  const logoStyle = "w-[80px] h-[32px] mb-0 min-w-max";
   const dropDownStyle = "w-[40px] h-[40px] mb-0";
   const textStyle = "text-Shades-0 text-base leading-normal no-underline";
   const mapPinStyle =
@@ -61,9 +61,9 @@ const Header = () => {
           </Link>
           <Link
             to="/"
-            className={`${textStyle} text-center w-[183px] font-semibold`}
+            className={`${textStyle} text-center min-w-max font-semibold`}
           >
-            HARVEST MISSION COMMUNITY CHURCH
+            HARVEST MISSION <br/> COMMUNITY CHURCH
           </Link>
           <button onClick={toggleModal}>
             <img alt="drop down" className={dropDownStyle} src={dropDown} />
@@ -74,8 +74,8 @@ const Header = () => {
           <Link to="/">
             <img alt="hmcc logo" className={logoStyle} src={hmccLogo} />
           </Link>
-          <Link to="/" className={`${textStyle} w-[183px] font-semibold`}>
-            HARVEST MISSION COMMUNITY CHURCH
+          <Link to="/" className={`${textStyle} min-w-max font-semibold`}>
+            HARVEST MISSION <br/> COMMUNITY CHURCH
           </Link>
         </div>
 
@@ -125,7 +125,7 @@ const Header = () => {
           </div>
         )}
 
-        <div className="flex-row items-center gap-4 hidden lg:flex lg:gap-3 [@media(min-width:1040px)]:gap-8 [@media(min-width:1440px)]:gap-11">
+        <div className="flex-row items-center gap-4 hidden lg:flex lg:gap-3 [@media(min-width:1040px)]:gap-8 [@media(min-width:1440px)]:gap-11 shrink-0">
           <div className="relative hover:bg-[#1A56D6] hover:border-[#1A56D6] hover:rounded-t-lg">
             <div className="hover:bg-[#1A56D6] hover:border-[#1A56D6] py-2 px-2 rounded-t-lg peer">
               <img
@@ -163,12 +163,12 @@ const Header = () => {
             </div>
           </div>
 
-          <div className="flex flex-row items-center gap-4 md:gap:6 [@media(min-width:1040px)]:gap-8 [@media(min-width:1440px)]:gap-11">
+          <div className="flex flex-row items-center justify-items-center gap-2 md:gap:4 [@media(min-width:1040px)]:gap-6 [@media(min-width:1440px)]:gap-11">
             {browseList.map((item, index) => (
               <Link
                 key={`browseLink-${index}`}
                 to={item.route}
-                className={`${textStyle} ${
+                className={`${"min-w-max"} ${textStyle} ${
                   item.route + "/" === path
                     ? "font-extrabold hover:bg-Primary-300 py-2 px-4 rounded-default"
                     : "font-normal hover:bg-Primary-300 py-2 px-4 rounded-default"
@@ -182,7 +182,7 @@ const Header = () => {
           <div className={borderStyle}>
             <Link
               to="/new"
-              className={`${textStyle} ${
+              className={`${"min-w-max"} ${textStyle} ${
                 "/new/" === path ? "font-extrabold" : ""
               } font-bold hover:font-extrabold tracking-[0.96px]`}
             >

--- a/frontend/src/components/header.js
+++ b/frontend/src/components/header.js
@@ -27,7 +27,7 @@ const Header = () => {
   const path =
     (typeof window !== "undefined" && window.location.pathname) || "";
   const containerStyle =
-    "flex flex-row h-[60px]lg:h-[100px] relative flext-start bg-Primary-700 items-center justify-center pl-[18px] xl:pl-[80.286px] lg:pt-[40px] lg:pb-[17px] pr-[16px] 2xl:pr-[65px] [@media(min-width:1440px)]:gap-[140px] [@media(min-width:1600px)]:gap-[220px] position-fixed";
+    "flex flex-row h-[60px] lg:h-[100px] relative flext-start bg-Primary-700 items-center justify-center pl-[18px] xl:pl-[80.286px] lg:pt-[40px] lg:pb-[17px] pr-[16px] 2xl:pr-[65px] [@media(min-width:1140px)]:gap-[40px] [@media(min-width:1440px)]:gap-[100px] [@media(min-width:1600px)]:gap-[210px] position-fixed";
   const logoStyle = "w-[80px] h-[32px] mb-0 min-w-max";
   const dropDownStyle = "w-[40px] h-[40px] mb-0";
   const textStyle = "text-Shades-0 text-base leading-normal no-underline";
@@ -125,8 +125,8 @@ const Header = () => {
           </div>
         )}
 
-        <div className="flex-row items-center gap-4 hidden lg:flex lg:gap-3 [@media(min-width:1040px)]:gap-8 [@media(min-width:1440px)]:gap-11 shrink-0">
-          <div className="relative hover:bg-[#1A56D6] hover:border-[#1A56D6] hover:rounded-t-lg">
+        <div className="flex-row items-center gap-4 hidden lg:flex lg:gap-3 [@media(min-width:1140px)]:gap-8 [@media(min-width:1440px)]:gap-11 shrink-0">
+          <div className="relative hover:bg-[#1A56D6] hover:border-[#1A56D6] hover:rounded-t-lg shrink-0">
             <div className="hover:bg-[#1A56D6] hover:border-[#1A56D6] py-2 px-2 rounded-t-lg peer">
               <img
                 alt="map pin logo"
@@ -163,7 +163,7 @@ const Header = () => {
             </div>
           </div>
 
-          <div className="flex flex-row items-center justify-items-center gap-2 md:gap:4 [@media(min-width:1040px)]:gap-6 [@media(min-width:1440px)]:gap-11">
+          <div className="flex flex-row items-center justify-items-center gap-2 md:gap:4 [@media(min-width:1140px)]:gap-4 [@media(min-width:1280px)]:gap-6 [@media(min-width:1440px)]:gap-11">
             {browseList.map((item, index) => (
               <Link
                 key={`browseLink-${index}`}

--- a/frontend/src/components/header.js
+++ b/frontend/src/components/header.js
@@ -168,7 +168,7 @@ const Header = () => {
               <Link
                 key={`browseLink-${index}`}
                 to={item.route}
-                className={`${"min-w-max"} ${textStyle} ${
+                className={`min-w-max ${textStyle} ${
                   item.route + "/" === path
                     ? "font-extrabold hover:bg-Primary-300 py-2 px-4 rounded-default"
                     : "font-normal hover:bg-Primary-300 py-2 px-4 rounded-default"

--- a/frontend/src/components/page-events/prayerGatheringEvents.js
+++ b/frontend/src/components/page-events/prayerGatheringEvents.js
@@ -19,11 +19,7 @@ const PrayerGatheringEvents = () => {
       </div>
 
       <div className="mt-8 sm:mt-4 max-w-[32.5rem] sm:px-[3.625rem] py-6 mb-4 bg-Shades-0 bg-opacity-80 rounded-2xl border-2 border-cyan-700 justify-center gap-1 sm:gap-2">
-<<<<<<< HEAD
         <div className="w-full px-8 sm:px-0 sm:max-w-96 text-center mx-auto text-black text-2xl sm:text-xl font-medium">
-=======
-        <div className="w-full px-8 sm:px-0 sm:max-w-96 text-center mx-auto text-black text-3xl sm:text-xl font-medium">
->>>>>>> 5a0eb4e (Linter)
           We meet once a month on <span className="font-bold">Thursday</span>{" "}
           from <span className="font-bold">7-9 pm</span> at the{" "}
           <span className="font-bold">T-center</span>.

--- a/frontend/src/components/page-events/prayerGatheringEvents.js
+++ b/frontend/src/components/page-events/prayerGatheringEvents.js
@@ -19,7 +19,11 @@ const PrayerGatheringEvents = () => {
       </div>
 
       <div className="mt-8 sm:mt-4 max-w-[32.5rem] sm:px-[3.625rem] py-6 mb-4 bg-Shades-0 bg-opacity-80 rounded-2xl border-2 border-cyan-700 justify-center gap-1 sm:gap-2">
+<<<<<<< HEAD
         <div className="w-full px-8 sm:px-0 sm:max-w-96 text-center mx-auto text-black text-2xl sm:text-xl font-medium">
+=======
+        <div className="w-full px-8 sm:px-0 sm:max-w-96 text-center mx-auto text-black text-3xl sm:text-xl font-medium">
+>>>>>>> 5a0eb4e (Linter)
           We meet once a month on <span className="font-bold">Thursday</span>{" "}
           from <span className="font-bold">7-9 pm</span> at the{" "}
           <span className="font-bold">T-center</span>.


### PR DESCRIPTION
previously this was happening
<img width="765" alt="Screenshot 2024-01-30 at 2 46 42 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/31eaabce-3a06-42f9-aea6-3aec6cf53598">

now text does not wrap
<img width="995" alt="Screenshot 2024-01-30 at 2 47 20 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/e22b3b80-f8ee-495c-a6e8-77bf8c10f4c0">
<img width="875" alt="Screenshot 2024-01-30 at 2 47 34 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/32ec7462-2aa1-479c-afa3-234b3ba69ff6">
<img width="777" alt="Screenshot 2024-01-30 at 2 47 47 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/e9b81ead-f7be-4487-9877-b9cf2f7eada6">