### PR TITLE
Fix safari navbar logo issue and #136 horizontal scroll bar on pages

### DIFF
--- a/frontend/src/components/header.js
+++ b/frontend/src/components/header.js
@@ -27,7 +27,7 @@ const Header = () => {
   const path =
     (typeof window !== "undefined" && window.location.pathname) || "";
   const containerStyle =
-    "flex flex-row h-[60px] lg:h-[100px] relative flext-start bg-Primary-700 items-center justify-center pl-[18px] xl:pl-[80.286px] lg:pt-[40px] lg:pb-[17px] pr-[16px] 2xl:pr-[65px] [@media(min-width:1140px)]:gap-[40px] [@media(min-width:1440px)]:gap-[100px] [@media(min-width:1600px)]:gap-[210px] position-fixed";
+    "flex flex-row h-[60px] lg:h-[100px] relative flext-start bg-Primary-700 items-center justify-between px-[16px] lg:pt-[40px] lg:pb-[17px] 2xl:px-[65px] [@media(min-width:1140px)]:gap-[40px] [@media(min-width:1440px)]:gap-[100px] [@media(min-width:1600px)]:gap-[210px] position-fixed";
   const logoStyle = "w-[80px] h-[32px] mb-0 min-w-max";
   const dropDownStyle = "w-[40px] h-[40px] mb-0";
   const textStyle = "text-Shades-0 text-base leading-normal no-underline";

--- a/frontend/src/components/header.js
+++ b/frontend/src/components/header.js
@@ -28,7 +28,7 @@ const Header = () => {
     (typeof window !== "undefined" && window.location.pathname) || "";
   const containerStyle =
     "flex flex-row h-[60px] lg:h-[100px] relative flext-start bg-Primary-700 items-center justify-between px-4 lg:pt-[40px] lg:pb-[17px] 2xl:px-[65px] [@media(min-width:1140px)]:gap-[40px] [@media(min-width:1440px)]:gap-[100px] [@media(min-width:1600px)]:gap-[210px] position-fixed";
-  const logoStyle = "w-[80px] h-[32px] mb-0";
+  const logoStyle = "w-20 h-8 mb-0";
   const dropDownStyle = "w-[40px] h-[40px] mb-0";
   const textStyle = "text-Shades-0 text-base leading-normal no-underline";
   const mapPinStyle =

--- a/frontend/src/components/header.js
+++ b/frontend/src/components/header.js
@@ -28,7 +28,7 @@ const Header = () => {
     (typeof window !== "undefined" && window.location.pathname) || "";
   const containerStyle =
     "flex flex-row h-[60px] lg:h-[100px] relative flext-start bg-Primary-700 items-center justify-between px-[16px] lg:pt-[40px] lg:pb-[17px] 2xl:px-[65px] [@media(min-width:1140px)]:gap-[40px] [@media(min-width:1440px)]:gap-[100px] [@media(min-width:1600px)]:gap-[210px] position-fixed";
-  const logoStyle = "w-[80px] h-[32px] mb-0 min-w-max";
+  const logoStyle = "w-[80px] h-[32px] mb-0";
   const dropDownStyle = "w-[40px] h-[40px] mb-0";
   const textStyle = "text-Shades-0 text-base leading-normal no-underline";
   const mapPinStyle =
@@ -70,7 +70,7 @@ const Header = () => {
           </button>
         </div>
 
-        <div className="hidden lg:flex items-center gap-4 md:gap-6 lg:gap-8">
+        <div className="hidden lg:flex items-center gap-4 md:gap-6 lg:gap-8 shrink-0">
           <Link to="/">
             <img alt="hmcc logo" className={logoStyle} src={hmccLogo} />
           </Link>

--- a/frontend/src/components/header.js
+++ b/frontend/src/components/header.js
@@ -27,7 +27,7 @@ const Header = () => {
   const path =
     (typeof window !== "undefined" && window.location.pathname) || "";
   const containerStyle =
-    "flex flex-row h-[60px] lg:h-[100px] relative flext-start bg-Primary-700 items-center justify-between px-[16px] lg:pt-[40px] lg:pb-[17px] 2xl:px-[65px] [@media(min-width:1140px)]:gap-[40px] [@media(min-width:1440px)]:gap-[100px] [@media(min-width:1600px)]:gap-[210px] position-fixed";
+    "flex flex-row h-[60px] lg:h-[100px] relative flext-start bg-Primary-700 items-center justify-between px-4 lg:pt-[40px] lg:pb-[17px] 2xl:px-[65px] [@media(min-width:1140px)]:gap-[40px] [@media(min-width:1440px)]:gap-[100px] [@media(min-width:1600px)]:gap-[210px] position-fixed";
   const logoStyle = "w-[80px] h-[32px] mb-0";
   const dropDownStyle = "w-[40px] h-[40px] mb-0";
   const textStyle = "text-Shades-0 text-base leading-normal no-underline";

--- a/frontend/src/components/shared/banner.js
+++ b/frontend/src/components/shared/banner.js
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 const Banner = ({ children, bgImage }) => (
-  <div className={`w-screen bg-cover ${bgImage}`}>
+  <div className={`w-full bg-cover ${bgImage}`}>
     <div className="flex flex-col items-center justify-center min-h-[6.25rem] lg:min-h-[17.5rem] w-full bg-[rgba(6,_20,_51,_0.8)]">
       <h1 className="uppercase text-xl lg:text-5xl font-bold leading-tighter tracking-medium-wide mb-0 text-Shades-0">
         {children}


### PR DESCRIPTION
safari navbar was making the logo super wide before this change. issue was due to min-width not being supported. it was removed and it works now. try to open safari either on phone or desktop and resize the screen down to mobile view.

before
<img width="571" alt="Screenshot 2024-02-06 at 2 23 14 AM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/a9dabdb0-4846-43e8-b3b8-7ce5d3b49544">

this pr
<img width="568" alt="Screenshot 2024-02-06 at 2 20 20 AM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/32930a62-b0a8-452e-bc83-e15bc1a23c91">

also improved overall look of different window sizes. previously there was a lot of extra space on either side at a specific width. it is now removed.

before
<img width="1113" alt="Screenshot 2024-02-06 at 2 22 40 AM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/a7973dc5-f520-4c16-a6e4-0d79e778fcd3">

this pr
<img width="977" alt="Screenshot 2024-02-06 at 2 23 55 AM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/3aae020f-cc5b-4530-a20c-b7c5b2faffb6">
