### PR TITLE
Fix rightnow media link issue #131

### DIFF
--- a/frontend/src/components/page-watch/rightNowMedia.js
+++ b/frontend/src/components/page-watch/rightNowMedia.js
@@ -41,7 +41,7 @@ const RightNowMedia = () => (
         </div>
         <div className="flex justify-center lg:justify-start">
           <SecondaryButtonLink
-            href="#"
+            href="https://www.rightnowmedia.org/Account/Invite/HMCC"
             hasArrow={true}
             className="bg-Shades-0"
             customClassName={{


### PR DESCRIPTION
look at bottom left tooltip, shows proper link
<img width="1363" alt="Screenshot 2024-02-17 at 9 40 20 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/1f49b1f7-cf4a-45a8-a7c3-24fe93abb4e8">
