### PR TITLE
Centered text on mobile nav fix issue #186

### DIFF
--- a/frontend/src/components/header.js
+++ b/frontend/src/components/header.js
@@ -65,7 +65,7 @@ const Header = () => {
           >
             HARVEST MISSION <br /> COMMUNITY CHURCH
           </Link>
-          <button onClick={toggleModal}>
+          <button onClick={toggleModal} className="ml-10">
             <img alt="drop down" className={dropDownStyle} src={dropDown} />
           </button>
         </div>


### PR DESCRIPTION
tested on safari too and it works

smallest screen size that people will be using, most devices have a larger width

<img width="639" alt="Screenshot 2024-03-14 at 3 58 52 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/ff71807f-670d-4490-8222-1ca8fa34c07d">

<img width="534" alt="Screenshot 2024-03-14 at 3 59 57 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/00c0abd9-5cdf-4523-ace9-dec5f7f6e3be">
