### PR TITLE
fix #82 Spacing on web view on about page is off

### DIFF
--- a/frontend/src/components/page-about/index/leadership.js
+++ b/frontend/src/components/page-about/index/leadership.js
@@ -40,7 +40,7 @@ const LeadershipSection = () => {
   ));
 
   return (
-    <div className="pt-4 lg:pt-16 pb-[2.5625rem] lg:pb-20.25 flex flex-col items-center max-w-container">
+    <div className="py-10 lg:py-20 flex flex-col items-center max-w-container">
       <div className="text-center pb-14.5">
         <div className="subheading">Our Leadership</div>
         <h2>Meet Our Elders</h2>

--- a/frontend/src/css/belief.module.css
+++ b/frontend/src/css/belief.module.css
@@ -1,7 +1,7 @@
 @config "../config/tailwind.config.js";
 
 .container {
-  @apply pb-[2.875rem] lg:pb-[8.875rem] pt-8 lg:pt-31 max-w-container w-full;
+  @apply py-10 lg:py-20 max-w-container w-full;
 }
 
 .title-container {

--- a/frontend/src/css/strategy.module.css
+++ b/frontend/src/css/strategy.module.css
@@ -28,7 +28,7 @@
 }
 
 .container {
-  @apply lg:pb-20.25 pt-8 lg:pt-[10.625rem] max-w-container;
+  @apply lg:py-20 pt-10 max-w-container;
 }
 
 .svg-container {


### PR DESCRIPTION
standardized spacing between components in about page

on mobile 80px padding between the sections listed under issue #82
<img width="622" alt="Screenshot 2024-04-11 at 5 35 59 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/7bd7816c-5528-4021-ac97-75c40ac53ac0">
<img width="647" alt="Screenshot 2024-04-11 at 5 36 16 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/2cb1a3c5-eb67-4027-bae7-1a187ad553e9">

on desktop 160px padding between same sections
<img width="1029" alt="Screenshot 2024-04-11 at 5 37 10 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/869345c5-a56b-4adc-8b5c-9fbf5f2bff51">
<img width="1039" alt="Screenshot 2024-04-11 at 5 37 21 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/28a72893-cd53-4b97-ace2-ddfecb48d0ea">
