### PR TITLE
Fix got questions multi line break #224

### DIFF
--- a/frontend/src/components/gotQuestions.js
+++ b/frontend/src/components/gotQuestions.js
@@ -3,7 +3,7 @@ import { MailIcon } from "./svgs";
 
 const Questions = () => (
   <div className="pb-[1.125rem] pt-5 lg:py-15 max-w-container w-full">
-    <div className="flex flex-col lg:flex-row gap-5 xl:gap-x-10 py-5  px-[0.875rem] items-center justify-center border-2 border-Neutral-600  rounded-xl">
+    <div className="flex flex-col xl:flex-row gap-5 xl:gap-x-10 py-5 px-[0.875rem] items-center justify-center border-2 border-Neutral-600 rounded-xl">
       <div>
         <h2 className="text-2xl lg:text-5xl font-bold lg:font-semibold lg:tracking-medium-wide text-center sm:text-left">
           GOT ANY QUESTIONS?


### PR DESCRIPTION
changes into rows on larger screen than before to prevent multiple lines as described in 224

<img width="926" alt="Screenshot 2024-04-21 at 9 26 44 PM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/0d708340-5656-41e8-b29c-4c31955f075d">
