### PR TITLE
Fix map being covered in smaller screens fix #213

### DIFF
--- a/frontend/src/components/page-connect/map-details.js
+++ b/frontend/src/components/page-connect/map-details.js
@@ -4,14 +4,14 @@ import { SecondaryButtonLink } from "../Button";
 
 const MapDetails = () => {
   return (
-    <div className="flex flex-col gap-y-5 md:gap-y-0 justify-center pt-5 md:pt-0 bg-Neutral-200 md:flex-row md:rounded-2xl max-w-[58.625rem] mx-auto">
-      <div className="md:px-[3.925rem] gap-5">
-        <div className="flex flex-col justify-center items-center text-center md:gap-8 md:py-[4.75rem]">
+    <div className="flex flex-col gap-y-5 lg:gap-y-0 justify-center pt-5 lg:pt-0 bg-Neutral-200 lg:flex-row lg:rounded-2xl max-w-[58.625rem] mx-auto">
+      <div className="lg:px-[3.925rem] gap-5">
+        <div className="flex flex-col justify-center items-center text-center lg:gap-8 lg:py-[4.75rem]">
           <p className="text-lg font-medium leading-tighter mb-0 text-Shades-100">
             Sunday Mornings <br />{" "}
             <span className="font-bold text-xl text-Shades-100">10 AM</span>
           </p>
-          <div className="flex flex-col gap-1 md:gap-5">
+          <div className="flex flex-col gap-1 lg:gap-5">
             <p className="mb-0">
               <span className="font-medium text-lg">Transformation Center</span>
               <br />{" "}
@@ -29,7 +29,7 @@ const MapDetails = () => {
           </div>
         </div>
       </div>
-      <div className="flex justify-center pb-2 md:p-2">
+      <div className="flex justify-center pb-2 lg:p-2">
         <StaticImage
           src="../../images/connect-map-parking.png"
           alt=""


### PR DESCRIPTION
issue #213 was already addressed in a previous commit but the issue was never closed. normans pr #248 can be closed.

in this pr i made the breakpoint happen sooner since parts of the map was being covered up when resizing the screen.

before
<img width="772" alt="Screenshot 2024-07-03 at 12 52 39 AM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/023132d6-ed2e-4877-b9eb-6873b57ee3c0">

after
<img width="963" alt="Screenshot 2024-07-03 at 12 52 13 AM" src="https://github.com/hmcc-global/hmccaa-web/assets/88253868/52d4fd62-bc3e-4e71-90e1-77ae4f750801">
