### PR TITLE
Fix #278 Vertical spacing on last section of all pages + fix major spacing bugs 

### DIFF
--- a/frontend/src/components/gotQuestions.js
+++ b/frontend/src/components/gotQuestions.js
@@ -2,7 +2,7 @@ import * as React from "react";
 import { MailIcon } from "./svgs";
 
 const Questions = () => (
-  <div className="pb-[1.125rem] pt-5 lg:py-15 max-w-container w-full">
+  <div className="pb-[1.125rem] pt-5 max-w-container w-full">
     <div className="flex flex-col xl:flex-row gap-5 xl:gap-x-10 py-5 px-[0.875rem] items-center justify-center border-2 border-Neutral-600 rounded-xl">
       <div>
         <h2 className="text-2xl lg:text-5xl font-bold lg:font-semibold lg:tracking-medium-wide text-center sm:text-left">

--- a/frontend/src/components/layout.js
+++ b/frontend/src/components/layout.js
@@ -29,6 +29,7 @@ const Layout = ({ children }) => {
       <main className="flex flex-col items-center bg-Shades-0 overflow-x-hidden">
         {children}
       </main>
+      <div className="py-[200px] bg-Primary-50"></div>
       <Footer />
     </div>
   );

--- a/frontend/src/components/layout.js
+++ b/frontend/src/components/layout.js
@@ -12,7 +12,11 @@ import Header from "./header";
 import "./layout.css";
 import Footer from "./footer";
 
-const Layout = ({ children }) => {
+const Layout = ({
+  children,
+  hasSpacing = true,
+  spacingColor = "bg-Shades-0",
+}) => {
   const data = useStaticQuery(graphql`
     query SiteTitleQuery {
       site {
@@ -29,7 +33,7 @@ const Layout = ({ children }) => {
       <main className="flex flex-col items-center bg-Shades-0 overflow-x-hidden">
         {children}
       </main>
-      <div className="py-[200px] bg-Primary-50"></div>
+      {hasSpacing && <div className={`py-20 ${spacingColor}`}></div>}
       <Footer />
     </div>
   );

--- a/frontend/src/components/layout.js
+++ b/frontend/src/components/layout.js
@@ -33,7 +33,7 @@ const Layout = ({
       <main className="flex flex-col items-center bg-Shades-0 overflow-x-hidden">
         {children}
       </main>
-      {hasSpacing && <div className={`py-20 ${spacingColor}`}></div>}
+      {hasSpacing && <div className={`py-10 lg:py-20 ${spacingColor}`}></div>}
       <Footer />
     </div>
   );

--- a/frontend/src/components/page-about/index/leadership.js
+++ b/frontend/src/components/page-about/index/leadership.js
@@ -41,7 +41,7 @@ const LeadershipSection = () => {
 
   return (
     <div className="py-10 lg:py-20 flex flex-col items-center max-w-container">
-      <div className="text-center pb-14.5">
+      <div className="text-center pb-[3.75rem]">
         <div className="subheading">Our Leadership</div>
         <h2>Meet Our Elders</h2>
       </div>

--- a/frontend/src/components/page-events/prayerGatheringEvents.js
+++ b/frontend/src/components/page-events/prayerGatheringEvents.js
@@ -2,7 +2,7 @@ import * as React from "react";
 
 const PrayerGatheringEvents = () => {
   return (
-    <div className="bg-Neutral-200 w-full justify-center flex flex-col items-center px-6 sm:px-2 pt-[2.5rem] pb-40">
+    <div className="bg-Neutral-200 w-full justify-center flex flex-col items-center px-6 sm:px-2 pt-[2.5rem] pb-20 lg:pb-40">
       <div className="flex-col justify-start items-center gap-y-2 flex mt-2">
         <div className="subheading">PRAYER GATHERINGS</div>
 

--- a/frontend/src/components/page-events/prayerGatheringEvents.js
+++ b/frontend/src/components/page-events/prayerGatheringEvents.js
@@ -2,7 +2,7 @@ import * as React from "react";
 
 const PrayerGatheringEvents = () => {
   return (
-    <div className="bg-Neutral-200 w-full justify-center flex flex-col items-center px-6 sm:px-2 py-[40px]">
+    <div className="bg-Neutral-200 w-full justify-center flex flex-col items-center px-6 sm:px-2 pt-[2.5rem] pb-40">
       <div className="flex-col justify-start items-center gap-y-2 flex mt-2">
         <div className="subheading">PRAYER GATHERINGS</div>
 

--- a/frontend/src/components/page-main/getconnected.js
+++ b/frontend/src/components/page-main/getconnected.js
@@ -17,7 +17,7 @@ const GetConnectedText = () => (
   <div className="w-full flex-col xl:py-5 justify-center text-center">
     <div className="subheading">Get Connected</div>
     <h2>There is a place for you at HMCC.</h2>
-    <p className="pt-21">
+    <p className="pt-5">
       New to Michigan? Coming for school? Looking for community? Whether you
       know God or not, we welcome you! We have fellowship for all different life
       stages, from youth to students to working adults or married couples!
@@ -90,7 +90,7 @@ const lgsArray = [
 ];
 
 const GetConnectedCircleDesktop = () => (
-  <div className="2 w-full pt-[16rem] pb-[8rem] px-10">
+  <div className="2 w-full pt-[12rem] pb-[8rem] px-10">
     <div>
       <div
         className={

--- a/frontend/src/components/page-main/getinvolved.js
+++ b/frontend/src/components/page-main/getinvolved.js
@@ -36,7 +36,7 @@ const linkClassnames =
   "flex py-3 px-5 flex-col text-Accent-500 font-bold tracking-medium-wide underline uppercase";
 
 const GetInvolved = () => (
-  <div className="py-5 md:py-10 flex max-w-container w-full justify-center">
+  <div className="pt-40 pb-10 md:pb-15 flex max-w-container w-full justify-center">
     <div className="border-2 border-solid border-Neutral-600 rounded-2xl pt-5 pb-[3.125rem] md:py-20 flex justify-center items-center w-full px-4 md:px-8">
       <div className="w-full max-w-[61.25rem] flex flex-col gap-y-10 items-center">
         <div className="text-center">

--- a/frontend/src/pages/about/index.js
+++ b/frontend/src/pages/about/index.js
@@ -16,7 +16,7 @@ import Banner from "../../components/shared/banner";
 export const Head = () => <Seo title="About" />;
 
 const AboutPage = () => (
-  <Layout>
+  <Layout spacingColor="bg-Neutral-200">
     <Banner bgImage="bg-about bg-[center_top] ">About Us</Banner>
     <div className="content-padding-full">
       <OurStory />

--- a/frontend/src/pages/connect/index.js
+++ b/frontend/src/pages/connect/index.js
@@ -13,7 +13,7 @@ const ConnectPage = () => (
   <Layout hasSpacing={false}>
     <Banner bgImage="bg-connect bg-[center_top]">Connect</Banner>
     <div className="content-padding-full">
-      <div className="max-w-container flex flex-col items-center pb-10 lg:pb-40">
+      <div className="max-w-container flex flex-col items-center pb-20 lg:pb-40">
         <SundayCelebration />
         <MapDetails />
         <CommonQuestions />

--- a/frontend/src/pages/connect/index.js
+++ b/frontend/src/pages/connect/index.js
@@ -10,10 +10,10 @@ import MapDetails from "../../components/page-connect/map-details";
 import CommonQuestions from "../../components/page-connect/common-questions";
 
 const ConnectPage = () => (
-  <Layout>
+  <Layout hasSpacing={false}>
     <Banner bgImage="bg-connect bg-[center_top]">Connect</Banner>
     <div className="content-padding-full">
-      <div className="max-w-container flex flex-col items-center">
+      <div className="max-w-container flex flex-col items-center pb-10 lg:pb-40">
         <SundayCelebration />
         <MapDetails />
         <CommonQuestions />

--- a/frontend/src/pages/events/index.js
+++ b/frontend/src/pages/events/index.js
@@ -20,7 +20,7 @@ const EventsPage = ({ data }) => {
   let events = filterEventTimes(processEvents(data?.allStrapiEvent?.nodes));
 
   return (
-    <Layout>
+    <Layout hasSpacing={false}>
       <Banner bgImage="bg-center bg-events">Upcoming Events</Banner>
       <SundayCelebBarEvents />
       {events.length === 0 ? (


### PR DESCRIPTION
layout template component adds two default parameters for whether or not spacing is needed and the color

## last section and footer (3 different variants)
default with white background, most pages look have this
<img width="1404" alt="Screenshot 2024-07-15 at 7 05 34 PM" src="https://github.com/user-attachments/assets/0be3653c-fad8-4826-8394-918f0806329f">
some backgrounds have a different color like this feedback form section
<img width="1362" alt="Screenshot 2024-07-15 at 7 05 49 PM" src="https://github.com/user-attachments/assets/0ec55863-8101-42b8-afa7-cdefcef366c7">
spacing between got questions and ig bar is 160px
<img width="1393" alt="Screenshot 2024-07-15 at 7 06 04 PM" src="https://github.com/user-attachments/assets/7c5aa35b-4342-4f8d-805d-09fa20f01d34">

some pages like the baptism one have larger than 160px padding
<img width="1401" alt="Screenshot 2024-07-15 at 7 08 42 PM" src="https://github.com/user-attachments/assets/1e28b434-e7ff-448e-8038-14750a8709f2">

## mobile responsive, shrinks down to 80px
<img width="646" alt="Screenshot 2024-07-15 at 7 09 40 PM" src="https://github.com/user-attachments/assets/8bc1b78e-35df-4c9e-88ff-ec7e93fda47d">
<img width="688" alt="Screenshot 2024-07-15 at 7 09 58 PM" src="https://github.com/user-attachments/assets/37d50730-f736-472f-9000-d3bbff52b6df">
<img width="679" alt="Screenshot 2024-07-15 at 7 10 13 PM" src="https://github.com/user-attachments/assets/6b10fad0-61a6-49b2-a3f6-1ea2d6b0b30b">

## get connected spacing fixed
top of section previously was too far down
<img width="1362" alt="Screenshot 2024-07-15 at 7 11 23 PM" src="https://github.com/user-attachments/assets/f18e5383-9e11-4b97-a238-ab9a0c854fc4">
header text is now 20px from the body text
<img width="926" alt="Screenshot 2024-07-15 at 7 11 31 PM" src="https://github.com/user-attachments/assets/a8f62d6e-aebf-4a1d-a585-bea918c8c50a">
increased spacing from next section to be roughly 160px
<img width="1071" alt="Screenshot 2024-07-15 at 7 11 38 PM" src="https://github.com/user-attachments/assets/78085f12-408f-46c1-9371-500e795d9359">

## text being too close to images fixed here
<img width="1324" alt="Screenshot 2024-07-15 at 7 13 45 PM" src="https://github.com/user-attachments/assets/2ee3ab3d-97d8-4a28-8c51-f276b2fc7a2a">
