### PR TITLE
fix sunday celebration alignment/padding in im new page

### DIFF
--- a/frontend/src/components/page-new/sunday-celebration.js
+++ b/frontend/src/components/page-new/sunday-celebration.js
@@ -12,10 +12,10 @@ const SundayCelebrationSection = () => {
   return (
     <div className="bg-Neutral-200 w-full flex justify-center items-center p-6 lg:py-16">
       <div
-        className={`flex flex-col bg-Shades-0 items-center h-full border-solid border-2 max-w-container rounded-xl py-6 px-10 border-Neutral-700 lg:px-16 lg:py-10 ${containerLg}`}
+        className={`flex flex-col bg-Shades-0 items-center h-full border-solid border-2 max-w-container rounded-xl py-6 px-6 border-Neutral-700 lg:px-16 lg:py-10 ${containerLg}`}
       >
         <div className={`flex justify-evenly pb-5 lg:pb-0 ${titleLg}`}>
-          <h2 className="text-[24px] lg:text-[48px]">Sunday Celebration</h2>
+          <h2 className="text-center text-[24px] lg:text-left lg:text-[48px]">Sunday Celebration</h2>
         </div>
         <div className={`text-center pb-5 lg:pb-0 ${timeLg} lg:text-[20px]`}>
           Sunday Mornings


### PR DESCRIPTION
only mobile view is affected by this change.

old: 
![image](https://github.com/user-attachments/assets/fdfe20e1-b12b-46f7-890d-bb4e7f6501f4)

new:

![image](https://github.com/user-attachments/assets/f46ae9f3-6d98-4396-b9c8-8aa1dcc0cf00)

desktop view should have no change