### PR TITLE
Move gatsby cache to docker volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - ./frontend/:/home/node/frontend/
       - ./cms/:/home/node/cms/
       - ./setup/:/home/node/setup/
+      - gatsby_cache:/home/node/frontend/.cache
       - gatsby_node_modules:/home/node/frontend/node_modules/
       - strapi_node_modules:/home/node/cms/node_modules/
     networks:
@@ -40,6 +41,7 @@ services:
 
 volumes:
   strapi-data:
+  gatsby_cache:
   gatsby_node_modules:
   strapi_node_modules:
 


### PR DESCRIPTION
Some files in gatsby cache are limited to root access, and this messes with husky's ability to format/check files. Because of currently existing prettierignore bugs, this cannot be fixed by adding the right directories to .prettierignore. Thus, this change will allow husky to freely edit files without being bothered by files in the cache (as long as `git push` is called from outside the docker container... which it should be, considering the container doesn't have git installed...)