### PR TITLE
add notification bar and custom page frontend

### DIFF
--- a/frontend/gatsby-config.js
+++ b/frontend/gatsby-config.js
@@ -40,6 +40,7 @@ module.exports = {
         apiURL: process.env.STRAPI_API_URL,
         token: process.env.STRAPI_TOKEN,
         collectionTypes: [
+          "custom-page",
           "sermon",
           "sermon-series",
           "sermon-topic",
@@ -49,7 +50,7 @@ module.exports = {
           "event",
           "event-template",
         ],
-        singleTypes: [],
+        singleTypes: ["notification-bar"],
       },
     },
     {

--- a/frontend/gatsby-node.js
+++ b/frontend/gatsby-node.js
@@ -10,6 +10,7 @@
 
 const { CreateEventPages } = require("./src/page-generation/events");
 const { CreateSermonPages } = require("./src/page-generation/sermons");
+const { CreateCustomPages } = require("./src/page-generation/custom");
 const { Pages } = require("./src/page-generation/create-page");
 
 exports.createPages = async ({ graphql, actions, reporter }) => {
@@ -21,6 +22,8 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
   await CreateEventPages(graphql, createPageFn, reporter);
 
   await CreateSermonPages(graphql, createPageFn, reporter);
+
+  await CreateCustomPages(graphql, createPageFn, reporter);
 
   pages.createPages();
 };

--- a/frontend/src/components/shared/notificationBar.js
+++ b/frontend/src/components/shared/notificationBar.js
@@ -25,10 +25,8 @@ const NotificationBar = () => {
             className="w-[1.875rem]"
           />
         </div>
-        <div className="inline lg:flex lg:gap-4">
-          <div className="inline pr-4 lg:px-0 pl-4 sm:pl-0">
-            <RichText data={data?.Text} />
-          </div>
+        <div className="inline lg:flex lg:gap-4 notification-text-container">
+          <RichText data={data?.Text} />
         </div>
       </div>
     </div>

--- a/frontend/src/components/shared/notificationBar.js
+++ b/frontend/src/components/shared/notificationBar.js
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { graphql, useStaticQuery } from "gatsby";
+import { StaticImage } from "gatsby-plugin-image";
+import RichText from "./richText";
+
+const NotificationBar = () => {
+  const data = useStaticQuery(graphql`
+    query notificationBarQuery {
+      strapiNotificationBar {
+        ShowNotificationBar
+        Text
+      }
+    }
+  `).strapiNotificationBar;
+
+  console.log(data);
+
+  return data?.ShowNotificationBar === true ? (
+    <div className="bg-Accent-50 text-[#2f3300] font-medium text-xl text-center py-[0.9375rem] flex justify-center">
+      <div className="sm:flex sm:gap-4 lg:items-center lg:max-w-none px-2 [@media(min-width:425px)]:px-8 [@media(min-width:550px)]:px-24 sm:px-16 lg:px-4 text-center sm:text-left lg:text-center">
+        <div className="inline">
+          <StaticImage
+            src="../../images/icons/bell.png"
+            alt="bell icon"
+            className="w-[1.875rem]"
+          />
+        </div>
+        <div className="inline lg:flex lg:gap-4">
+          <div className="inline pr-4 lg:px-0 pl-4 sm:pl-0">
+            <RichText data={data?.Text} />
+          </div>
+        </div>
+      </div>
+    </div>
+  ) : (
+    ""
+  );
+};
+
+export default NotificationBar;

--- a/frontend/src/components/shared/richText.js
+++ b/frontend/src/components/shared/richText.js
@@ -1,0 +1,134 @@
+import React from "react";
+import Link from "../Link";
+
+const formatText = ({ text, code, bold, italic, underline, strikethrough }) => {
+  if (text === "") {
+    return "";
+  }
+  const style = `whitespace-pre-wrap ${bold ? "font-bold" : ""}  ${
+    italic ? "italic" : ""
+  } ${underline ? "underline" : ""} ${strikethrough ? "line-through" : ""}`;
+  const span = <span className={style}>{text}</span>;
+  return code ? <code>{span}</code> : span;
+};
+
+const formatLink = ({ url, children }) => {
+  return (
+    <Link
+      href={url}
+      className="text-Accent-500 underline font-bold whitespace-nowrap inline"
+    >
+      {formatParagraph(children)}
+    </Link>
+  );
+};
+
+const formatParagraph = children => {
+  return children.map(child => {
+    switch (child.type) {
+      case "link":
+        return formatLink(child);
+      case "text":
+      default:
+        return formatText(child);
+    }
+  });
+};
+
+const formatOrderedList = children => {
+  return (
+    <ol className="list-decimal list-inside">
+      {children.map((child, idx) => (
+        <li key={idx}>{formatParagraph(child.children)}</li>
+      ))}
+    </ol>
+  );
+};
+
+const formatUnorderedList = children => {
+  return (
+    <ul className="list-disc list-inside">
+      {children.map((child, idx) => (
+        <li key={idx}>{formatParagraph(child.children)}</li>
+      ))}
+    </ul>
+  );
+};
+
+const formatHeading = (level, children) => {
+  const text = formatParagraph(children);
+  const headingStyle = "text-center";
+  switch (level) {
+    case 1:
+      return <h2 className={headingStyle}>{text}</h2>;
+    case 2:
+      return <h2 className={headingStyle}>{text}</h2>;
+    case 3:
+      return <h3 className={headingStyle}>{text}</h3>;
+    case 4:
+      return <h4 className={headingStyle}>{text}</h4>;
+    case 5:
+      return <h5 className={headingStyle}>{text}</h5>;
+    case 6:
+      return <h6 className={headingStyle}>{text}</h6>;
+    default:
+      return text;
+  }
+};
+
+const formatNode = ({ type, format, level, image, children }) => {
+  switch (type) {
+    case "image":
+      return (
+        <img
+          src={image.url}
+          alt={image.alternativeText}
+          className="flex justify-center items-center content-image lg:w-1/3"
+        />
+      );
+    case "heading":
+      return formatHeading(level, children);
+    case "quote":
+      return (
+        <blockquote className="block ms-4 me-4 my-1">
+          {formatParagraph(children)}
+        </blockquote>
+      );
+    case "code":
+      return (
+        <pre>
+          <code>{children[0].text}</code>
+        </pre>
+      );
+    case "list":
+      switch (format) {
+        case "ordered":
+          return formatOrderedList(children);
+        case "unordered":
+          return formatUnorderedList(children);
+        default: // Treat unknown format case as regular paragraph
+          break;
+      }
+    case "paragraph":
+    default: // Treat default case as regular paragraph
+      return <div>{formatParagraph(children)}</div>;
+  }
+};
+
+const RichText = ({ data, addPaddingToParagraphs = false }) => {
+  if (!Array.isArray(data)) {
+    return "";
+  }
+
+  return (
+    <div>
+      {data.map((node, idx) => (
+        <div key={idx} className={addPaddingToParagraphs ? "my-3" : ""}>
+          {formatNode(node)}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default RichText;

--- a/frontend/src/components/shared/richText.js
+++ b/frontend/src/components/shared/richText.js
@@ -7,7 +7,9 @@ const formatText = ({ text, code, bold, italic, underline, strikethrough }) => {
   }
   const style = `whitespace-pre-wrap ${bold ? "font-bold" : ""}  ${
     italic ? "italic" : ""
-  } ${underline ? "underline" : ""} ${strikethrough ? "line-through" : ""}`;
+  } ${underline ? "underline" : ""} ${
+    strikethrough ? "line-through" : ""
+  }`.trim();
   const span = <span className={style}>{text}</span>;
   return code ? <code>{span}</code> : span;
 };
@@ -16,7 +18,7 @@ const formatLink = ({ url, children }) => {
   return (
     <Link
       href={url}
-      className="text-Accent-500 underline font-bold whitespace-nowrap inline"
+      className="text-Accent-500 underline font-bold whitespace-nowrap inline-block"
     >
       {formatParagraph(children)}
     </Link>
@@ -80,11 +82,13 @@ const formatNode = ({ type, format, level, image, children }) => {
   switch (type) {
     case "image":
       return (
-        <img
-          src={image.url}
-          alt={image.alternativeText}
-          className="flex justify-center items-center content-image lg:w-1/3"
-        />
+        <div>
+          <img
+            src={image.url}
+            alt={image.alternativeText}
+            className="flex justify-center items-center content-image lg:w-1/3"
+          />
+        </div>
       );
     case "heading":
       return formatHeading(level, children);
@@ -110,24 +114,24 @@ const formatNode = ({ type, format, level, image, children }) => {
           break;
       }
     case "paragraph":
+      return <p>{formatParagraph(children)}</p>;
     default: // Treat default case as regular paragraph
       return <div>{formatParagraph(children)}</div>;
   }
 };
 
-const RichText = ({ data, addPaddingToParagraphs = false }) => {
+const RichText = ({ data }) => {
+  console.log(data);
   if (!Array.isArray(data)) {
     return "";
   }
 
   return (
-    <div>
+    <>
       {data.map((node, idx) => (
-        <div key={idx} className={addPaddingToParagraphs ? "my-3" : ""}>
-          {formatNode(node)}
-        </div>
+        <React.Fragment key={idx}>{formatNode(node)}</React.Fragment>
       ))}
-    </div>
+    </>
   );
 };
 

--- a/frontend/src/css/global.css
+++ b/frontend/src/css/global.css
@@ -140,3 +140,11 @@ span.ellipsis {
 .collapsible-items .toggle p:nth-child(2) {
   @apply mt-5 lg:mt-6;
 }
+
+.notification-text-container > div {
+  @apply inline pr-4 lg:px-0 pl-4 sm:pl-0;
+}
+
+.notification-text-container p {
+  @apply mb-0;
+}

--- a/frontend/src/page-generation/custom.js
+++ b/frontend/src/page-generation/custom.js
@@ -1,0 +1,31 @@
+const path = require("path");
+
+async function CreateCustomPages(graphql, createPage, reporter) {
+  // GraphQL Query for All Sermons
+  const result = await graphql(`
+    {
+      allStrapiCustomPage {
+        nodes {
+          URL
+        }
+      }
+    }
+  `);
+
+  if (result.errors) {
+    reporter.panicOnBuild(`Error while querying graphql for custom page URLs`);
+    return;
+  }
+
+  result.data.allStrapiCustomPage?.nodes
+    ?.map(({ URL }) => URL)
+    .forEach(url => {
+      createPage({
+        path: url,
+        component: path.resolve("./src/templates/customPage.js"),
+        context: { url },
+      });
+    });
+}
+
+module.exports.CreateCustomPages = CreateCustomPages;

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -7,34 +7,12 @@ import WelcomeMain from "../components/page-main/welcomeMain";
 import UpcomingEvents from "../components/page-main/upcoming";
 import GetConnectedCircle from "../components/page-main/getconnected";
 import GetInvolved from "../components/page-main/getinvolved";
-import Link from "../components/Link";
+import NotificationBar from "../components/shared/notificationBar";
 
 const IndexPage = () => (
   <Layout>
     <div className="w-full">
-      <div className="bg-Accent-50 text-[#2f3300] font-medium text-xl text-center py-[0.9375rem] flex justify-center">
-        <div className="sm:flex sm:gap-4 lg:items-center lg:max-w-none px-2 [@media(min-width:425px)]:px-8 [@media(min-width:550px)]:px-24 sm:px-16 lg:px-4 text-center sm:text-left lg:text-center">
-          <div className="inline">
-            <StaticImage
-              src="../images/icons/bell.png"
-              alt="bell icon"
-              className="w-[1.875rem]"
-            />
-          </div>
-          <div className="inline lg:flex lg:gap-4">
-            <div className="inline pr-4 lg:px-0 pl-4 sm:pl-0">
-              <span className="font-bold">Life Group</span> is one of the best
-              ways to experience community at HMCC.{" "}
-            </div>
-            <Link
-              to="/next-steps/lifegroups"
-              className="text-Accent-500 underline font-bold whitespace-nowrap inline"
-            >
-              Sign up today!
-            </Link>
-          </div>
-        </div>
-      </div>
+      <NotificationBar />
       <div className="relative text-center text-Shades-0">
         <StaticImage
           className="w-full h-full mb-0"

--- a/frontend/src/templates/customPage.js
+++ b/frontend/src/templates/customPage.js
@@ -16,7 +16,7 @@ const CustomPage = ({ data }) => {
       <Banner bgImage={`bg-[center_60%] ${background}`}>
         {pageData?.Title}
       </Banner>
-      <div className="content-padding-full w-3 py-[0.9375rem] px-2 [@media(min-width:425px)]:px-8 [@media(min-width:550px)]:px-24 sm:px-16 lg:px-4">
+      <div className="content-padding-full w-3 py-[0.9375rem] px-2 [@media(min-width:425px)]:px-8 [@media(min-width:550px)]:px-24 sm:px-16 lg:px-4 flex gap-y-3 [&>*]:w-full">
         <RichText data={pageData?.Content} addPaddingToParagraphs={true} />
       </div>
     </Layout>

--- a/frontend/src/templates/customPage.js
+++ b/frontend/src/templates/customPage.js
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { graphql } from "gatsby";
+import Layout from "../components/layout";
+import Seo from "../components/seo";
+import Banner from "../components/shared/banner";
+import RichText from "../components/shared/richText";
+
+const CustomPage = ({ data }) => {
+  const pageData = data.strapiCustomPage;
+  // TODO: this doesn't load the banner image properly into tailwind, so we will stick with the default for now.
+  // const url = pageData?.BannerImage?.file?.publicURL;
+  // const background = url ? `bg-[url(http://localhost:8000${url})]` : "bg-events";
+  const background = "bg-events";
+  return (
+    <Layout hasSpacing={false}>
+      <Banner bgImage={`bg-[center_60%] ${background}`}>
+        {pageData?.Title}
+      </Banner>
+      <div className="content-padding-full w-3 py-[0.9375rem] px-2 [@media(min-width:425px)]:px-8 [@media(min-width:550px)]:px-24 sm:px-16 lg:px-4">
+        <RichText data={pageData?.Content} addPaddingToParagraphs={true} />
+      </div>
+    </Layout>
+  );
+};
+
+export const Head = ({ data }) => (
+  <Seo
+    title={data.strapiCustomPage?.Title}
+    description="Please join us in person on Sundays at the T-center. But if you cannot, come worship with us through our live stream! You can find our past sermons here too."
+  />
+);
+
+export const pageQuery = graphql`
+  query customPageQuery($url: String!) {
+    strapiCustomPage(URL: { eq: $url }) {
+      URL
+      Title
+      BannerImage {
+        file {
+          publicURL
+        }
+      }
+      Content
+      BottomButton {
+        Text
+        Hyperlink
+      }
+    }
+  }
+`;
+
+export default CustomPage;

--- a/frontend/src/templates/customPage.js
+++ b/frontend/src/templates/customPage.js
@@ -17,7 +17,7 @@ const CustomPage = ({ data }) => {
         {pageData?.Title}
       </Banner>
       <div className="content-padding-full w-3 py-[0.9375rem] px-2 [@media(min-width:425px)]:px-8 [@media(min-width:550px)]:px-24 sm:px-16 lg:px-4 flex gap-y-3 [&>*]:w-full">
-        <RichText data={pageData?.Content} addPaddingToParagraphs={true} />
+        <RichText data={pageData?.Content} />
       </div>
     </Layout>
   );


### PR DESCRIPTION
Desktop view looks the same:

![image](https://github.com/user-attachments/assets/03a97b75-69e4-45ce-a460-9c8decd73a72)


but unfortunately mobile view looks jank. couldn't figure out how to fix it (aka bring the "sign up now" down to the new line without specially hardcoding it

![image](https://github.com/user-attachments/assets/f9c27c85-0447-4e7d-a205-3391f27656cb)


Also created a custom page:

![image](https://github.com/user-attachments/assets/dbe7d2c2-45cf-46b1-b13e-06f6aed7b36f)

(you can use build this exact custom page yourself if you copy the data from production strapi, I put a copy there as well.