### PR TITLE
Increase Strapi database connection pool limits

### DIFF
--- a/cms/ecosystem.config.js
+++ b/cms/ecosystem.config.js
@@ -15,6 +15,7 @@ module.exports = {
       script: "npm run start",
       env: {
         NODE_ENV: "production",
+        DATABASE_POOL_MAX: "64",
       },
     },
   ],


### PR DESCRIPTION
I think the previous limit (default was 10) was getting hit and causing connections to get dropped and certain graphql requests to fail