### PR TITLE
Fix layout inconsistencies and improve trait label display

### DIFF
--- a/frontend/src/components/page-watch/index/sermons.js
+++ b/frontend/src/components/page-watch/index/sermons.js
@@ -171,8 +171,8 @@ const Sermons = ({
             options={traitInfo.traits
               .sort(SermonTraitMetadata.get(traitInfo.field).sortingFn)
               .map(trait => ({
-                label: trait,
-                value: normalizeTrait(trait),
+                label: trait.replace(/_/g, " "), // Replace underscores with spaces for display
+                value: normalizeTrait(trait), // Keep normalized value for URLs
               }))}
             handleChange={handleChange}
             currentlySelected={currentlySelectedTraits[idx]}

--- a/frontend/src/components/page-watch/index/sermons.js
+++ b/frontend/src/components/page-watch/index/sermons.js
@@ -162,7 +162,7 @@ const Sermons = ({
       </div>
       <div
         id="sermons-filter"
-        className="grid grid-cols-2 gap-y-3  max-w-[17rem] lg:max-w-none xs:max-w-[23.5rem] lg:flex w-full justify-center gap-x-4 lg:gap-x-5  "
+        className="grid grid-cols-2 gap-y-3  lg:max-w-none xs:max-w-[23.5rem] lg:flex w-full justify-center gap-x-4 lg:gap-x-5  "
       >
         {traits.map((traitInfo, idx) => (
           <ComboBox
@@ -182,7 +182,7 @@ const Sermons = ({
       </div>
       <div
         id="sermons-list-paged"
-        className="grid grid-cols-2 lg:grid-cols-3 gap-x-4 lg:gap-x-5 lg:gap-y-8  py-[2px] lg:py-5"
+        className="grid grid-cols-2 lg:grid-cols-3 gap-4 lg:gap-x-5 lg:gap-y-8  py-[2px] lg:py-5"
       >
         {nodes.map(
           (


### PR DESCRIPTION
Address layout inconsistencies in the sermons component and enhance the display of trait labels by replacing underscores with spaces. Also added gap to the y axis to space out cards

<img width="416" alt="Screenshot 2025-03-21 at 2 51 29 PM" src="https://github.com/user-attachments/assets/6c7f5773-e770-400f-ac93-bf0f639509a6" />

<img width="220" alt="Screenshot 2025-03-21 at 2 51 59 PM" src="https://github.com/user-attachments/assets/4e17ef05-e95e-45a8-b57f-7971c2e4a409" />

<img width="429" alt="Screenshot 2025-03-21 at 2 52 14 PM" src="https://github.com/user-attachments/assets/57277426-974e-4d83-b73f-b7ef1d27a355" />


