### PR TITLE
Hotfix 20250904: Remove 'break-all' class from formatText style for improved text form…

### DIFF
--- a/frontend/src/components/shared/richText.js
+++ b/frontend/src/components/shared/richText.js
@@ -9,7 +9,7 @@ const formatText = (
   if (text === "") {
     return "";
   }
-  const style = `whitespace-pre-wrap break-all ${bold ? "font-bold" : ""}  ${
+  const style = `whitespace-pre-wrap ${bold ? "font-bold" : ""}  ${
     italic ? "italic" : ""
   } ${underline ? "underline" : ""} ${
     strikethrough ? "line-through" : ""


### PR DESCRIPTION
…atting consistency (#547)