### PR TITLE
Change strapi trigger to cause sites to build in succession

### DIFF
--- a/.github/workflows/publish-backend-changes.yml
+++ b/.github/workflows/publish-backend-changes.yml
@@ -5,10 +5,11 @@ on:
     types: [strapi_updated]
 
 jobs:
-  deploy-dev-site:
-    uses: ./.github/workflows/component-deploy-dev.yml
-    secrets: inherit
-
   deploy-prod-site:
     uses: ./.github/workflows/component-deploy-prod.yml
+    secrets: inherit
+
+  deploy-dev-site:
+    needs: deploy-prod-site
+    uses: ./.github/workflows/component-deploy-dev.yml
     secrets: inherit


### PR DESCRIPTION
Change strapi trigger to cause sites to build in succession rather than concurrently. Should speed up the prod build.