### PR TITLE
About page: pull elders from Strapi CMS

### DIFF
--- a/frontend/src/components/page-about/index/leadership.js
+++ b/frontend/src/components/page-about/index/leadership.js
@@ -1,40 +1,18 @@
 import * as React from "react";
-import imgPeteDahlem from "../../../images/about-elders-pete-dahlem.png";
-import imgJoshYang from "../../../images/about-elders-josh-yang.png";
-import imgDaveYon from "../../../images/about-elders-dave-yon.png";
-import imgSeongPark from "../../../images/about-elders-seong-park.png";
 import { SecondaryButtonLink } from "../../Button";
 import TeamCard from "../shared/teamCard";
 import Team from "../shared/team";
 
-const LeadershipSection = () => {
-  const elderInfo = [
-    {
-      img: imgPeteDahlem,
-      name: "Rev. Pete Dahlem",
-      role: "Lead Pastor",
-    },
-    {
-      img: imgJoshYang,
-      name: "Josh Yang",
-      role: "Associate Pastor",
-    },
-    {
-      img: imgDaveYon,
-      name: "Dave Yon",
-      role: "Elder",
-    },
-    {
-      img: imgSeongPark,
-      name: "Seong Park",
-      role: "Elder",
-    },
-  ];
-
-  const elderCards = elderInfo.map((info, index) => (
+const LeadershipSection = ({ elders = [] }) => {
+  const elderCards = elders.map((elder, index) => (
     <TeamCard
       key={`elder-${index + 1}`}
-      info={info}
+      info={{
+        gatsbyImageData:
+          elder.TeamMember?.Headshot?.file?.childImageSharp?.gatsbyImageData,
+        name: elder.TeamMember?.DisplayName,
+        role: elder.Role,
+      }}
       customClassName={{ container: "gap-y-2", h3: "text-2xl leading-tighter" }}
     />
   ));

--- a/frontend/src/pages/about/index.js
+++ b/frontend/src/pages/about/index.js
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { graphql } from "gatsby";
 
 import Layout from "../../components/layout";
 import Seo, { PageDescriptions } from "../../components/seo";
@@ -17,25 +18,48 @@ export const Head = () => (
   <Seo title="About" description={PageDescriptions.about} />
 );
 
-const AboutPage = () => (
-  <Layout spacingColor="bg-Neutral-200">
-    <Banner bgImage="bg-about bg-[center_top] ">About Us</Banner>
-    <div className="content-padding-full">
-      <OurStory />
-    </div>
-    <Mission />
-    <div className="content-padding-full">
-      <Values />
-      <LeadershipSection />
-      <Belief />
-    </div>
-    <Vision />
-    <div className="content-padding-full">
-      <Strategy />
-      <Partners />
-    </div>
-    <Feedback />
-  </Layout>
-);
+const AboutPage = ({ data: { strapiOurTeamPage } }) => {
+  const { Elders } = strapiOurTeamPage;
+  return (
+    <Layout spacingColor="bg-Neutral-200">
+      <Banner bgImage="bg-about bg-[center_top] ">About Us</Banner>
+      <div className="content-padding-full">
+        <OurStory />
+      </div>
+      <Mission />
+      <div className="content-padding-full">
+        <Values />
+        <LeadershipSection elders={Elders} />
+        <Belief />
+      </div>
+      <Vision />
+      <div className="content-padding-full">
+        <Strategy />
+        <Partners />
+      </div>
+      <Feedback />
+    </Layout>
+  );
+};
 
 export default AboutPage;
+
+export const pageQuery = graphql`
+  query AboutPageQuery {
+    strapiOurTeamPage {
+      Elders {
+        Role
+        TeamMember {
+          DisplayName
+          Headshot {
+            file {
+              childImageSharp {
+                gatsbyImageData
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- Replace hardcoded elder data and static image imports on the About page with a GraphQL query to `strapiOurTeamPage`
- Matches the same Strapi data pattern used by the Our Team page
- Only queries fields needed for the leadership cards (DisplayName, Headshot, Role)

## Test plan
- [ ] Verify About page still renders elder cards correctly
- [ ] Verify elder data matches what's in Strapi CMS

🤖 Generated with [Claude Code](https://claude.com/claude-code)