### PR TITLE
Fix ordinal date suffix for 11th, 12th, 13th

### DIFF
--- a/frontend/src/components/page-events/event-processing-util.js
+++ b/frontend/src/components/page-events/event-processing-util.js
@@ -59,6 +59,7 @@ const MONTHS = [
 ];
 
 const suffix = num => {
+  if (num >= 11 && num <= 13) return "th";
   if (num % 10 === 1) return "st";
   if (num % 10 === 2) return "nd";
   if (num % 10 === 3) return "rd";


### PR DESCRIPTION
## Summary
- Fix the `suffix` function in `event-processing-util.js` that produced wrong ordinals for teen numbers (e.g. "March 13rd" instead of "March 13th")
- Added guard clause for 11-13 to return "th" before the modulo checks

Closes #585

## Test plan
- [ ] Verify events on the 11th, 12th, 13th display correct suffixes
- [ ] Verify other dates (1st, 2nd, 3rd, 21st, 22nd, 23rd, 31st) still correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)