### PR TITLE
Clean up build log noise and remove audio deletion hack

### DIFF
--- a/.github/actions/validate-frontend/action.yml
+++ b/.github/actions/validate-frontend/action.yml
@@ -21,7 +21,7 @@ runs:
         echo 'STRAPI_TOKEN=${{ inputs.strapi_token }}' > ./.env.production
         echo 'STRAPI_API_URL=${{ inputs.strapi_server }}' >> ./.env.production
 
-        echo "Installing dependencies..."
+        echo "Running npm install..."
         npm install --loglevel=error
         NODE_ENV=production HOST_ORIGIN=${{ inputs.host_server }} npm run build
 

--- a/.github/actions/validate-frontend/action.yml
+++ b/.github/actions/validate-frontend/action.yml
@@ -21,7 +21,7 @@ runs:
         echo 'STRAPI_TOKEN=${{ inputs.strapi_token }}' > ./.env.production
         echo 'STRAPI_API_URL=${{ inputs.strapi_server }}' >> ./.env.production
 
-        npm install
+        npm install --loglevel=error
         NODE_ENV=production HOST_ORIGIN=${{ inputs.host_server }} npm run build
 
         echo "Finished build with error code $?"

--- a/.github/actions/validate-frontend/action.yml
+++ b/.github/actions/validate-frontend/action.yml
@@ -21,6 +21,7 @@ runs:
         echo 'STRAPI_TOKEN=${{ inputs.strapi_token }}' > ./.env.production
         echo 'STRAPI_API_URL=${{ inputs.strapi_server }}' >> ./.env.production
 
+        echo "Installing dependencies..."
         npm install --loglevel=error
         NODE_ENV=production HOST_ORIGIN=${{ inputs.host_server }} npm run build
 

--- a/.github/workflows/component-build.yml
+++ b/.github/workflows/component-build.yml
@@ -49,6 +49,7 @@ jobs:
           echo 'STRAPI_TOKEN=${{ secrets.strapi_token }}' > ./.env.${{ inputs.build_type }}
           echo 'STRAPI_API_URL=${{ secrets.strapi_api_url }}' >> ./.env.${{ inputs.build_type }}
 
+          echo "Installing dependencies..."
           npm install --loglevel=error
           NODE_ENV=${{ inputs.build_type }} HOST_ORIGIN=${{ secrets.host_server }} npm run build
       - name: Add anti-webscraping

--- a/.github/workflows/component-build.yml
+++ b/.github/workflows/component-build.yml
@@ -49,7 +49,7 @@ jobs:
           echo 'STRAPI_TOKEN=${{ secrets.strapi_token }}' > ./.env.${{ inputs.build_type }}
           echo 'STRAPI_API_URL=${{ secrets.strapi_api_url }}' >> ./.env.${{ inputs.build_type }}
 
-          npm install
+          npm install --loglevel=error
           NODE_ENV=${{ inputs.build_type }} HOST_ORIGIN=${{ secrets.host_server }} npm run build
       - name: Add anti-webscraping
         if: ${{ inputs.add_robots_txt }}

--- a/.github/workflows/component-build.yml
+++ b/.github/workflows/component-build.yml
@@ -49,7 +49,7 @@ jobs:
           echo 'STRAPI_TOKEN=${{ secrets.strapi_token }}' > ./.env.${{ inputs.build_type }}
           echo 'STRAPI_API_URL=${{ secrets.strapi_api_url }}' >> ./.env.${{ inputs.build_type }}
 
-          echo "Installing dependencies..."
+          echo "Running npm install..."
           npm install --loglevel=error
           NODE_ENV=${{ inputs.build_type }} HOST_ORIGIN=${{ secrets.host_server }} npm run build
       - name: Add anti-webscraping

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Validate Strapi
         run: | 
           cd ${{ github.workspace }}/cms
+          echo "Installing dependencies..."
           npm install --loglevel=error
           npm run build
           npm run strapi policies:list

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Validate Strapi
         run: | 
           cd ${{ github.workspace }}/cms
-          echo "Installing dependencies..."
+          echo "Running npm install..."
           npm install --loglevel=error
           npm run build
           npm run strapi policies:list

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Validate Strapi
         run: | 
           cd ${{ github.workspace }}/cms
-          npm install
+          npm install --loglevel=error
           npm run build
           npm run strapi policies:list
           npm run strapi middlewares:list

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Verify Strapi
         run: | 
           cd ${{ github.workspace }}/cms
-          echo "Installing dependencies..."
+          echo "Running npm install..."
           npm install --loglevel=error
           npm run build
           npm run strapi policies:list

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Verify Strapi
         run: | 
           cd ${{ github.workspace }}/cms
+          echo "Installing dependencies..."
           npm install --loglevel=error
           npm run build
           npm run strapi policies:list

--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Verify Strapi
         run: | 
           cd ${{ github.workspace }}/cms
-          npm install
+          npm install --loglevel=error
           npm run build
           npm run strapi policies:list
           npm run strapi middlewares:list

--- a/frontend/gatsby-node.js
+++ b/frontend/gatsby-node.js
@@ -21,22 +21,21 @@ function memoryLog(label) {
 
 exports.createPages = async ({ graphql, actions, reporter }) => {
   const { createPage } = actions;
+  const startTime = Date.now();
 
   let pages = new Pages(createPage, reporter);
   let createPageFn = page => pages.addPage(page);
-  let createPageAndPrintFn = page => {
-    reporter.info(`Creating page: ${page.path}`);
-    createPageFn(page);
-  };
 
-  await CreateEventPages(graphql, createPageAndPrintFn, reporter);
+  await CreateEventPages(graphql, createPageFn, reporter);
 
   await CreateSermonPages(graphql, createPageFn, reporter);
 
-  await CreateCustomPages(graphql, createPageAndPrintFn, reporter);
+  await CreateCustomPages(graphql, createPageFn, reporter);
 
   pages.createPages();
   memoryLog("createPages");
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log(`[DEBUG][build] Page creation finished in ${elapsed}s`);
 };
 
 exports.onPostBootstrap = ({ getNodes }) => {

--- a/frontend/gatsby-node.js
+++ b/frontend/gatsby-node.js
@@ -13,8 +13,11 @@ const { CreateSermonPages } = require("./src/page-generation/sermons");
 const { CreateCustomPages } = require("./src/page-generation/custom");
 const { Pages } = require("./src/page-generation/create-page");
 
-const fs = require("fs");
-const path = require("path");
+function memoryLog(label) {
+  const m = process.memoryUsage();
+  const mb = v => (v / 1024 / 1024).toFixed(0);
+  console.log(`[DEBUG][build:${label}] RSS: ${mb(m.rss)}MB, Heap: ${mb(m.heapUsed)}MB`);
+}
 
 exports.createPages = async ({ graphql, actions, reporter }) => {
   const { createPage } = actions;
@@ -33,168 +36,14 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
   await CreateCustomPages(graphql, createPageAndPrintFn, reporter);
 
   pages.createPages();
-};
-
-// Our site does care to download images, so that the image/sharp plugins
-// can optimize them and such, but we don't care to download audio files,
-// because all cases where we use them (aka just in sermon recordings) only
-// rely on the mp3 url and the frontend loads it directly from CMS with that
-// url.
-//
-// Unfortunately he `gatsby-source-strapi-graphql` plugin doesn't give us
-// an option to customize which file types we actually care to download.
-// Thus this hack just goes through and deletes all the audio files one by
-// one as they're being downloaded.
-//
-// This is important because over time the number of sermons tracked on the
-// website grows, and thus the amount of disk space being used to download
-// audios also grows - and each ~50MB file does add up. For example, we've
-// had issues where the free tier Github runner runs out of disk space and
-// fails as a result of downloading too many audio files.
-let totalFileBytes = 0;
-let totalDeletedBytes = 0;
-exports.onCreateNode = async ({ node, actions }) => {
-  const { deleteNode } = actions;
-
-  // Only care about File nodes (these represent actual files on disk)
-  if (node.internal.type === "File") {
-    let sizeBytes = 0;
-    try {
-      const stats = fs.statSync(node.absolutePath);
-      sizeBytes = stats.size;
-      totalFileBytes += sizeBytes;
-    } catch (err) {
-      console.log(
-        `[FileNode] Created: ${node.absolutePath} (size unknown: ${err.message})`
-      );
-    }
-
-    // Remove audio files to save on room
-    if (
-      node.extension &&
-      ["mp3", "wav", "flac"].includes(node.extension.toLowerCase())
-    ) {
-      try {
-        fs.unlinkSync(node.absolutePath);
-        totalDeletedBytes += sizeBytes;
-      } catch (err) {
-        console.error("Error deleting audio file:", err.message);
-      }
-
-      deleteNode({ node });
-    }
-  }
-};
-
-// ------- Log Memory on various steps and periodically -------
-
-// --- configurable settings ---
-const MEM_LOG_INTERVAL_MS = 30_000; // log every 3s0
-// ------------------------------
-
-let memInterval = null;
-
-function formatMem() {
-  const m = process.memoryUsage();
-  const toMB = v => (v / 1024 / 1024).toFixed(2);
-  return `rss=${toMB(m.rss)} MB, heapUsed=${toMB(
-    m.heapUsed
-  )} MB, heapTotal=${toMB(m.heapTotal)} MB, external=${toMB(m.external)} MB`;
-}
-
-function logMem(label) {
-  console.log(
-    `[${new Date().toISOString()}] [${label}] Memory: ${formatMem()}`
-  );
-}
-
-function startMemTicker(contextLabel = "ticker") {
-  if (memInterval) return; // avoid duplicates
-  memInterval = setInterval(() => {
-    logMem(contextLabel);
-  }, MEM_LOG_INTERVAL_MS);
-
-  // Ensure ticker doesn't keep Node alive if Gatsby tries to exit
-  memInterval.unref?.();
-}
-
-function stopMemTicker() {
-  if (memInterval) {
-    clearInterval(memInterval);
-    memInterval = null;
-  }
-}
-
-exports.onPreInit = () => {
-  logMem("onPreInit");
-  startMemTicker("build");
-};
-
-exports.onPreBootstrap = () => {
-  logMem("onPreBootstrap");
-};
-
-exports.createSchemaCustomization = () => {
-  logMem("createSchemaCustomization");
-};
-
-exports.sourceNodes = async args => {
-  logMem("before sourceNodes");
-  // You can wrap long-running source plugins with temporary timers if needed.
-  // Example: args.reporter.activityTimer("Custom sourceNodes timer").start()/end()
+  memoryLog("createPages");
 };
 
 exports.onPostBootstrap = ({ getNodes }) => {
-  logMem("onPostBootstrap");
-  console.log(`[nodes] count=${getNodes().length}`);
-};
-
-exports.onPreExtractQueries = () => {
-  logMem("onPreExtractQueries");
-  stopMemTicker();
+  console.log(`[DEBUG][build] Total nodes: ${getNodes().length}`);
 };
 
 exports.onPostBuild = ({ getNodes }) => {
-  logMem("onPostBuild");
-  console.log(
-    `[${new Date().toISOString()}] [nodes] final count=${getNodes().length}`
-  );
-  console.log(
-    `[${new Date().toISOString()}] [files created] sizeMB=${(
-      totalFileBytes /
-      1024 /
-      1024
-    ).toFixed(2)}`
-  );
-  console.log(
-    `[${new Date().toISOString()}] [files deleted] sizeMB=${(
-      totalDeletedBytes /
-      1024 /
-      1024
-    ).toFixed(2)}`
-  );
+  memoryLog("onPostBuild");
+  console.log(`[DEBUG][build] Done. Final node count: ${getNodes().length}`);
 };
-
-// Safety net: stop ticker if Gatsby exits unexpectedly
-process.on("exit", code => {
-  logMem(`process exit code=${code}`);
-  stopMemTicker();
-});
-process.on("SIGINT", () => {
-  logMem("SIGINT");
-  stopMemTicker();
-});
-process.on("SIGTERM", () => {
-  logMem("SIGTERM");
-  stopMemTicker();
-});
-process.on("uncaughtException", err => {
-  console.error("[uncaughtException]", err && (err.stack || err));
-  logMem("uncaughtException");
-  stopMemTicker();
-});
-process.on("unhandledRejection", reason => {
-  console.error("[unhandledRejection]", reason && (reason.stack || reason));
-  logMem("unhandledRejection");
-  stopMemTicker();
-});

--- a/frontend/gatsby-node.js
+++ b/frontend/gatsby-node.js
@@ -46,3 +46,20 @@ exports.onPostBuild = ({ getNodes }) => {
   memoryLog("onPostBuild");
   console.log(`[DEBUG][build] Done. Final node count: ${getNodes().length}`);
 };
+
+// Suppress "Conflicting order" warnings from mini-css-extract-plugin.
+// These fire when different pages import the same CSS modules in different
+// orders, which is harmless with Tailwind/CSS Modules but produces a lot
+// of noise in the build logs.
+exports.onCreateWebpackConfig = ({ stage, actions, getConfig }) => {
+  if (stage === "build-javascript") {
+    const config = getConfig();
+    const miniCssPlugin = config.plugins.find(
+      plugin => plugin.constructor.name === "MiniCssExtractPlugin"
+    );
+    if (miniCssPlugin) {
+      miniCssPlugin.options.ignoreOrder = true;
+    }
+    actions.replaceWebpackConfig(config);
+  }
+};

--- a/frontend/src/components/page-watch/index/sermons.js
+++ b/frontend/src/components/page-watch/index/sermons.js
@@ -149,7 +149,7 @@ const Sermons = ({
         <img src={`${process.env.STRAPI_API_URL}${url}`} alt={SeriesName} />
       );
     }
-    console.log(`Did not find background img for sermon series ${SeriesName}.`);
+    console.warn(`[DEBUG][sermon-series] Missing background image for series "${SeriesName}"`);
     return <div className="py-5 w-full"></div>;
   };
 

--- a/frontend/src/components/shared/notificationBar.js
+++ b/frontend/src/components/shared/notificationBar.js
@@ -13,8 +13,6 @@ const NotificationBar = () => {
     }
   `).strapiNotificationBar;
 
-  console.log(data);
-
   return data?.ShowNotificationBar === true ? (
     <div className="bg-Accent-50 text-[#2f3300] font-medium text-xl text-left py-[0.9375rem] flex justify-center">
       <div className="sm:flex sm:gap-4 lg:items-center lg:max-w-none px-2 [@media(min-width:425px)]:px-8 [@media(min-width:550px)]:px-24 sm:px-16 lg:px-4 text-left">

--- a/frontend/src/components/shared/richText.js
+++ b/frontend/src/components/shared/richText.js
@@ -56,7 +56,6 @@ const formatParagraph = (children, addPaddingBelowParagraph = true) => {
         answer[answer.length - 1].text.length - END.length
       );
       answer[0].text = answer[0].text.slice(midIndexIndex + MID.length);
-      console.log("[RichText] Found Collapsible:", question, answer);
       return (
         <div className="pb-[1.3125rem] lg:pb-3">
           <Collapsible
@@ -67,11 +66,6 @@ const formatParagraph = (children, addPaddingBelowParagraph = true) => {
             }}
           />
         </div>
-      );
-    } else {
-      console.log(
-        "[RichText] Found collapsible but encountered error; formatting as text. Text:",
-        children
       );
     }
   }

--- a/frontend/src/components/shared/richText.js
+++ b/frontend/src/components/shared/richText.js
@@ -67,6 +67,9 @@ const formatParagraph = (children, addPaddingBelowParagraph = true) => {
           />
         </div>
       );
+    } else {
+      const preview = children[0]?.text?.slice(0, 80) || "(empty)";
+      console.warn(`[DEBUG][richText] Found collapsible tags but missing <collapsible-answer> marker; rendering as plain text. Preview: "${preview}"`);
     }
   }
 

--- a/frontend/src/page-generation/create-page.js
+++ b/frontend/src/page-generation/create-page.js
@@ -14,7 +14,7 @@ class Pages {
   }
 
   createPages() {
-    this.reporter.info(`${this.pages.length} pages to create...`);
+    this.reporter.info(`[DEBUG][createPages] ${this.pages.length} pages to create...`);
     const timer = this.reporter.activityTimer("Create All Pages");
     timer.start();
 

--- a/frontend/src/page-generation/custom.js
+++ b/frontend/src/page-generation/custom.js
@@ -17,16 +17,15 @@ async function CreateCustomPages(graphql, createPage, reporter) {
     return;
   }
 
-  result.data.allStrapiCustomPage?.nodes
-    ?.map(({ URL }) => URL)
-    .forEach(url => {
-      reporter.info(`Found custom page to create: ${url}`);
-      createPage({
-        path: url,
-        component: path.resolve("./src/templates/customPage.js"),
-        context: { url },
-      });
+  const urls = result.data.allStrapiCustomPage?.nodes?.map(({ URL }) => URL) || [];
+  reporter.info(`[DEBUG][createPages] Found ${urls.length} custom pages to create${urls.length ? ":\n" + urls.map(u => `  ${u}`).join("\n") : "."}`);
+  urls.forEach(url => {
+    createPage({
+      path: url,
+      component: path.resolve("./src/templates/customPage.js"),
+      context: { url },
     });
+  });
 }
 
 module.exports.CreateCustomPages = CreateCustomPages;

--- a/frontend/src/page-generation/events.js
+++ b/frontend/src/page-generation/events.js
@@ -101,7 +101,7 @@ async function CreateEventPages(graphql, createPage, reporter) {
     processEvents(eventResult.data.allStrapiEvent.nodes)
   );
 
-  reporter.info(`Found ${parsedEvents.length} events to create pages for.`);
+  reporter.info(`[DEBUG][createPages] Found ${parsedEvents.length} events to create pages for.`);
 
   parsedEvents.forEach(event => {
     if (!event.id || !event.times) {

--- a/frontend/src/page-generation/sermons.js
+++ b/frontend/src/page-generation/sermons.js
@@ -224,9 +224,9 @@ async function CreateSermonPages(graphql, createPage, reporter) {
   });
 
   sermonCollection.createPages(createPage);
-  reporter.info(`Found ${sermons.length} sermons to create pages for.`);
+  reporter.info(`[DEBUG][createPages] Found ${sermons.length} sermons to create pages for.`);
   reporter.info(
-    `Found ${sermonCollection.sermonGroups.size} sermon sorting groups to create pages for.`
+    `[DEBUG][createPages] Found ${sermonCollection.sermonGroups.size} sermon sorting groups to create pages for.`
   );
 }
 

--- a/frontend/src/pages/get-involved/lifegroups.js
+++ b/frontend/src/pages/get-involved/lifegroups.js
@@ -35,7 +35,6 @@ const LifeGroupsPage = ({
     breadcrumb: { crumbs },
   },
 }) => {
-  console.log(images, videoOembed, links);
   return (
     <Layout>
       <div className="px-1 [@media(min-width:375px)]:px-4 pt-[1.375rem] lg:pt-10 w-full ">

--- a/frontend/src/pages/get-involved/missions.js
+++ b/frontend/src/pages/get-involved/missions.js
@@ -71,8 +71,6 @@ const MissionsPage = ({
     links: obj.Links,
     description: obj.Description,
   }));
-  console.log("data", missions);
-
   return (
     <Layout>
       <div className="pt-[1.375rem] lg:pt-10 pb-[4.8125rem] lg:pb-[2.25rem] content-padding-full gap-y-5 lg:gap-y-15 min-h-screen">

--- a/frontend/src/templates/customPage.js
+++ b/frontend/src/templates/customPage.js
@@ -13,7 +13,6 @@ const CustomPage = ({ data }) => {
   const bgImageUrl = url ? `${process.env.HOST_ORIGIN}${url}` : null;
   const buttonText = pageData?.BottomButton?.Text;
   const buttonLink = pageData?.BottomButton?.Hyperlink;
-  console.log("[CustomPage] Generated banner url:", bgImageUrl || bgImage);
   return (
     <Layout hasSpacing={false} className="custom-page">
       <Banner bgImage={`bg-[center_60%] ${bgImage}`} bgImageUrl={bgImageUrl}>

--- a/frontend/src/templates/eventPageTemplate.js
+++ b/frontend/src/templates/eventPageTemplate.js
@@ -21,8 +21,6 @@ const EventPage = ({ pageContext }) => {
     breadcrumb: { crumbs },
   } = pageContext;
 
-  console.log(event);
-
   const { date: formattedDate, time: formattedTime } =
     formatEventTimeAsObject(time);
   return (

--- a/frontend/src/templates/sermon.js
+++ b/frontend/src/templates/sermon.js
@@ -29,15 +29,11 @@ const getSermonVideoPlayer = (videoLink, strapiId) => {
         js: "",
       };
     } catch (e) {
-      console.log(
-        `Could not parse sermon video link (strapiId ${strapiId}): \`${videoLink}\` because of error: ${e}.`
-      );
+      console.warn(`[DEBUG][sermon] Could not parse video link (strapiId ${strapiId}): "${videoLink}" — ${e}`);
       return null;
     }
   }
-  console.log(
-    `Could not parse sermon video link (strapiId ${strapiId}): \`${videoLink}\``
-  );
+  console.warn(`[DEBUG][sermon] Unrecognized video link format (strapiId ${strapiId}): "${videoLink}"`);
   return null;
 };
 


### PR DESCRIPTION
## Summary
- Remove the `onCreateNode` audio file deletion hack from `gatsby-node.js` — no longer needed after #599 added a download whitelist
- Remove periodic memory ticker, lifecycle memory logging, and process exit handlers — replaced with two memory checkpoints (after `createPages` and `onPostBuild`)
- Remove debug `console.log` statements from 8 frontend source files (event templates, sermon templates, custom pages, rich text, life groups, missions, notification bar, sermon series)
- Add `[DEBUG]` prefix to all remaining custom log output for easy Ctrl+F filtering
- Silence `npm install` noise in CI with `--loglevel=error` across all 4 workflow files

## Test plan
- [ ] PR build succeeds (validate-frontend workflow)
- [ ] Build logs are significantly cleaner — no more memory ticker spam, event/collapsible JSON dumps, or npm peer dep warnings
- [ ] `[DEBUG]` lines still appear in logs for memory checkpoints and sermon warnings
- [ ] Sermon pages with missing video links still log warnings (searchable via `[DEBUG][sermon]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)