### PR TITLE
Support YouTube short links (youtu.be) in sermon video player

### DIFF
--- a/frontend/src/components/shared/oembed.js
+++ b/frontend/src/components/shared/oembed.js
@@ -1,18 +1,5 @@
 import React from "react";
-
-function getYouTubeEmbedUrl(url) {
-  // Handle youtu.be/VIDEO_ID format
-  const shortMatch = url.match(/youtu\.be\/([a-zA-Z0-9_-]+)/);
-  if (shortMatch) {
-    return `https://www.youtube-nocookie.com/embed/${shortMatch[1]}`;
-  }
-  // Handle youtube.com/watch?v=VIDEO_ID format
-  const longMatch = url.match(/youtube\.com\/watch\?v=([a-zA-Z0-9_-]+)/);
-  if (longMatch) {
-    return `https://www.youtube-nocookie.com/embed/${longMatch[1]}`;
-  }
-  return null;
-}
+import { getYouTubeEmbedUrl } from "./videoUrl";
 
 function OEmbedVideo({ oembedString, className = "", fallbackUrl }) {
   let embedUrl = null;

--- a/frontend/src/components/shared/videoUrl.js
+++ b/frontend/src/components/shared/videoUrl.js
@@ -1,0 +1,33 @@
+/**
+ * Extracts a YouTube video ID from various URL formats and returns
+ * a privacy-enhanced embed URL.
+ *
+ * Supported formats:
+ *   - https://www.youtube.com/watch?v=VIDEO_ID
+ *   - https://youtu.be/VIDEO_ID
+ *   - https://m.youtu.be/VIDEO_ID
+ */
+export function getYouTubeEmbedUrl(url) {
+  // Handle youtu.be/VIDEO_ID format
+  const shortMatch = url.match(/youtu\.be\/([a-zA-Z0-9_-]+)/);
+  if (shortMatch) {
+    return `https://www.youtube-nocookie.com/embed/${shortMatch[1]}`;
+  }
+  // Handle youtube.com/watch?v=VIDEO_ID format
+  const longMatch = url.match(/youtube\.com\/watch\?v=([a-zA-Z0-9_-]+)/);
+  if (longMatch) {
+    return `https://www.youtube-nocookie.com/embed/${longMatch[1]}`;
+  }
+  return null;
+}
+
+/**
+ * Extracts a Vimeo video ID from a URL and returns an embed URL.
+ */
+export function getVimeoEmbedUrl(url) {
+  const match = url.match(/\d+/);
+  if (match) {
+    return `https://player.vimeo.com/video/${match[0]}?badge=0&autopause=0&player_id=0&app_id=58479`;
+  }
+  return null;
+}

--- a/frontend/src/templates/sermon.js
+++ b/frontend/src/templates/sermon.js
@@ -12,32 +12,28 @@ import Seo from "../components/seo";
 import { graphql } from "gatsby";
 import { mediaWrapper } from "../css/media.module.css";
 import { getSermonPageUrl } from "../page-generation/sermon-pages";
+import { getYouTubeEmbedUrl, getVimeoEmbedUrl } from "../components/shared/videoUrl";
 
 const getSermonVideoPlayer = (videoLink, strapiId) => {
-  if (videoLink?.includes("vimeo")) {
-    const videoID = videoLink.match(/\d+/).shift();
+  if (!videoLink) {
+    console.warn(`[DEBUG][sermon] Missing video link (strapiId ${strapiId})`);
+    return null;
+  }
+
+  const vimeoSrc = getVimeoEmbedUrl(videoLink);
+  if (videoLink.includes("vimeo") && vimeoSrc) {
     return {
-      src: `https://player.vimeo.com/video/${videoID}?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479`,
+      src: vimeoSrc,
       js: <script src="https://player.vimeo.com/api/player.js"></script>,
     };
-  } else if (videoLink?.includes("youtube")) {
-    try {
-      const url = new URL(videoLink);
-      const v = url.searchParams.get("v");
-      return {
-        src: `https://www.youtube-nocookie.com/embed/${v}`,
-        js: "",
-      };
-    } catch (e) {
-      console.log(
-        `Could not parse sermon video link (strapiId ${strapiId}): \`${videoLink}\` because of error: ${e}.`
-      );
-      return null;
-    }
   }
-  console.log(
-    `Could not parse sermon video link (strapiId ${strapiId}): \`${videoLink}\``
-  );
+
+  const youtubeSrc = getYouTubeEmbedUrl(videoLink);
+  if (youtubeSrc) {
+    return { src: youtubeSrc, js: "" };
+  }
+
+  console.warn(`[DEBUG][sermon] Unrecognized video link format (strapiId ${strapiId}): "${videoLink}"`);
   return null;
 };
 


### PR DESCRIPTION
## Summary
- Extract video URL parsing into shared utility (`src/components/shared/videoUrl.js`) with `getYouTubeEmbedUrl` and `getVimeoEmbedUrl`
- Fix sermon video player not recognizing `youtu.be` short links — now handles both `youtube.com/watch?v=ID` and `youtu.be/ID` formats
- Update `oembed.js` to import from shared utility instead of defining its own copy
- Add `[DEBUG]` prefixed warnings for missing/unrecognized video links

Fixes #476

## Test plan
- [ ] PR build succeeds
- [ ] Sermon pages with `youtube.com/watch?v=` links still embed correctly
- [ ] Sermon pages with `youtu.be/` short links now embed correctly (previously showed nothing)
- [ ] Vimeo sermon links still work
- [ ] Life groups page video (uses OEmbed component) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)