### PR TITLE
Fix 404 page by including .htaccess in build artifact

### DIFF
--- a/.github/workflows/component-build.yml
+++ b/.github/workflows/component-build.yml
@@ -61,4 +61,5 @@ jobs:
         with:
           name: ${{ inputs.artifact_name }}
           path: ./frontend/public/
+          include-hidden-files: true
           retention-days: 1

--- a/frontend/gatsby-config.js
+++ b/frontend/gatsby-config.js
@@ -227,13 +227,6 @@ module.exports = {
         // keep your 404 mapping
         ErrorDocument: "ErrorDocument 404 /404.html",
         custom: `
-<IfModule mod_rewrite.c>
-  RewriteEngine On
-  RewriteCond %{REQUEST_FILENAME} !-f
-  RewriteCond %{REQUEST_FILENAME} !-d
-  RewriteRule .+ /404.html [L]
-</IfModule>
-
 <IfModule mod_headers.c>
   <FilesMatch "\\.(png|jpe?g|gif|svg|webp|avif|ico|woff2?|ttf|otf|mp4|webm|mp3|wav)$">
     Header set Cache-Control "public, max-age=31536000, immutable"

--- a/frontend/gatsby-config.js
+++ b/frontend/gatsby-config.js
@@ -227,6 +227,13 @@ module.exports = {
         // keep your 404 mapping
         ErrorDocument: "ErrorDocument 404 /404.html",
         custom: `
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteRule .+ /404.html [L]
+</IfModule>
+
 <IfModule mod_headers.c>
   <FilesMatch "\\.(png|jpe?g|gif|svg|webp|avif|ico|woff2?|ttf|otf|mp4|webm|mp3|wav)$">
     Header set Cache-Control "public, max-age=31536000, immutable"


### PR DESCRIPTION
## Summary

- Fixes the broken 404 page — visitors see a raw Apache error instead of the custom page
- Root cause: `upload-artifact@v4.4.0` started excluding hidden files by default. Since `.htaccess` starts with a dot, it was silently dropped from the build artifact and never deployed to the server.
- Fix: add `include-hidden-files: true` to the upload step in `component-build.yml`

This also restores cache-control headers, ETag removal, compression, and all other `.htaccess` directives that haven't been reaching the server.

## Test plan

- [ ] Deploy to dev and verify `.htaccess` exists on the server
- [ ] Visit a non-existent URL (e.g., `/asdfasdf`) — should show the custom 404 page
- [ ] Check response headers: `curl -sI https://hmcc.net/` should show `Cache-Control: public, max-age=0, must-revalidate` (not `max-age=600`)
- [ ] Verify existing pages still load normally

Closes #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)